### PR TITLE
Add tests and ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "script",
+      globals: globals.node,
+    },
+    rules: {
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tbdsapcerpg",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node tests/server.test.js",
+    "lint": "eslint servers tests"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "globals": "^16.2.0"
+  }
+}

--- a/servers/git/index.js
+++ b/servers/git/index.js
@@ -9,3 +9,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`Git MCP server listening on port ${port}`);
 });
+server.on('error', (err) => console.error(err));

--- a/servers/postgres/index.js
+++ b/servers/postgres/index.js
@@ -9,3 +9,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`Postgres MCP server listening on port ${port}`);
 });
+server.on('error', (err) => console.error(err));

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,45 @@
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+const assert = require('assert');
+
+function startServer(relativePath, port) {
+  const fullPath = path.join(__dirname, '..', relativePath);
+  const env = { ...process.env, PORT: String(port) };
+  return spawn('node', [fullPath], { env });
+}
+
+function request(port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: 'localhost', port, path: '/' }, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+(async () => {
+  const gitPort = 8081;
+  const pgPort = 8004;
+  const git = startServer('servers/git/index.js', gitPort);
+  const pg = startServer('servers/postgres/index.js', pgPort);
+  // give servers time to start
+  await new Promise(r => setTimeout(r, 500));
+  try {
+    const gitResponse = await request(gitPort);
+    assert.strictEqual(gitResponse, 'Git MCP server placeholder');
+    const pgResponse = await request(pgPort);
+    assert.strictEqual(pgResponse, 'Postgres MCP server placeholder');
+    console.log('Tests passed');
+    git.kill();
+    pg.kill();
+  } catch (err) {
+    git.kill();
+    pg.kill();
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add basic test and lint setup
- migrate ESLint to modern config
- configure ESLint for Node environment

## Testing
- `npm test`
- `npx eslint servers tests`


------
https://chatgpt.com/codex/tasks/task_e_6860e004535483268dd08aaa8000a9c0