### PR TITLE
Add ConfigPath parameter to update script

### DIFF
--- a/update-mcp-config.ps1
+++ b/update-mcp-config.ps1
@@ -1,24 +1,29 @@
-# PowerShell script to update MCP configuration
-$configPath = "C:\Users\w1n51\.cursor\mcp.json"
+# update-mcp-config.ps1
+# Purpose: Update the fallback server workspace path in the MCP config file
+# Usage: .\update-mcp-config.ps1 [-ConfigPath <path>]
+
+param(
+    [string]$ConfigPath = "C:\Users\w1n51\.cursor\mcp.json"
+)
 
 # Check if the file exists
-if (Test-Path $configPath) {
-    Write-Host "Found MCP configuration at $configPath"
-    
+if (Test-Path $ConfigPath) {
+    Write-Host "Found MCP configuration at $ConfigPath"
+
     # Read the current configuration
-    $config = Get-Content -Path $configPath -Raw | ConvertFrom-Json
-    
+    $config = Get-Content -Path $ConfigPath -Raw | ConvertFrom-Json
+
     # Update the fallback server workspace path
     $config.mcpServers."mcp-unity-fallback".workspace = "C:/Users/w1n51/OneDrive/Desktop/Gamedev/TBD Space Game/TBD SpaceGame/TBD SpaceGame"
-    
+
     # Convert back to JSON and save
-    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $configPath
-    
+    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $ConfigPath
+
     Write-Host "Updated mcp-unity-fallback workspace path successfully"
 } else {
-    Write-Host "MCP configuration file not found at $configPath"
+    Write-Host "MCP configuration file not found at $ConfigPath"
 }
 
 # Output the current configuration
 Write-Host "Current MCP Configuration:"
-Get-Content -Path $configPath 
+Get-Content -Path $ConfigPath


### PR DESCRIPTION
## Summary
- add optional ConfigPath parameter to update-mcp-config.ps1 so file ops can use custom paths
- use parameter throughout and document usage
- remove trailing whitespace

## Testing
- `pwsh -File tests/test-servers.ps1`
- `pwsh -Command "Invoke-ScriptAnalyzer -Path . -Recurse"`

------
https://chatgpt.com/codex/tasks/task_e_6860dffee86c8326b9e6cad2cba92544