### PR TITLE
Validate MCP script parameters and add newline endings

### DIFF
--- a/execute-mcp-command.ps1
+++ b/execute-mcp-command.ps1
@@ -4,17 +4,20 @@ param (
     [string]$menuPath
 )
 
+if ([string]::IsNullOrWhiteSpace($menuPath)) {
+    Write-Error "menuPath cannot be empty"
+    exit 1
+}
+
 # Output what we're doing
 Write-Host "Executing MCP menu item: $menuPath"
 
 # Form the JSON payload
-$payload = @{
+$payload = [PSCustomObject]@{
     method = "execute_menu_item"
-    params = @{
-        menuPath = $menuPath
-    }
+    params = @{ menuPath = [string]$menuPath }
     id = [guid]::NewGuid().ToString()
-} | ConvertTo-Json -Depth 3
+} | ConvertTo-Json -Depth 3 -Compress
 
 # Execute the command using Invoke-WebRequest
 try {
@@ -23,4 +26,4 @@ try {
 }
 catch {
     Write-Host "Error executing MCP command: $_"
-} 
+}

--- a/execute-mcp-message.ps1
+++ b/execute-mcp-message.ps1
@@ -4,18 +4,20 @@ param (
     [string]$message
 )
 
+if ([string]::IsNullOrWhiteSpace($message)) {
+    Write-Error "message cannot be empty"
+    exit 1
+}
+
 # Output what we're doing
 Write-Host "Sending message to Unity: $message"
 
 # Form the JSON payload
-$payload = @{
+$payload = [PSCustomObject]@{
     method = "notify_message"
-    params = @{
-        message = $message
-        logType = "Log"  # Can be: Log, Warning, Error
-    }
+    params = @{ message = [string]$message; logType = "Log" }
     id = [guid]::NewGuid().ToString()
-} | ConvertTo-Json -Depth 3
+} | ConvertTo-Json -Depth 3 -Compress
 
 # Execute the command using Invoke-WebRequest
 try {
@@ -24,4 +26,4 @@ try {
 }
 catch {
     Write-Host "Error executing MCP command: $_"
-} 
+}


### PR DESCRIPTION
## Summary
- enforce non-empty `menuPath` and `message` parameters before forming JSON
- build payload with `PSCustomObject` to avoid unwanted property injection
- ensure scripts end with newline characters

## Testing
- `pwsh -Command "./tests/test-servers.ps1"`
- `pwsh -Command "Invoke-ScriptAnalyzer -Path . -Recurse"`


------
https://chatgpt.com/codex/tasks/task_e_6860e00dde148326a8eb40855a8db5c6