### PR TITLE
Validate menu paths before execution

### DIFF
--- a/test-menu.ps1
+++ b/test-menu.ps1
@@ -264,6 +264,13 @@ else {
     Write-Log "Testing multiple menu items: $($MenuPaths.Count) items" "INFO"
 }
 
+# Validate provided paths before executing
+for ($i = 0; $i -lt $pathsToTest.Count; $i++) {
+    if ([string]::IsNullOrWhiteSpace($pathsToTest[$i])) {
+        throw "Menu path at position $($i + 1) is null, empty, or whitespace."
+    }
+}
+
 # Verify server is running
 if (-not (Test-Server)) {
     Write-Log "MCP server does not appear to be running on port $Port." "WARNING"

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -21,6 +21,10 @@ try {
     $pgResponse = Invoke-WebRequest -Uri "http://localhost:$PostgresPort" -UseBasicParsing -TimeoutSec 5
     Write-Host "Postgres server responded: $($pgResponse.Content)"
 } finally {
-    Stop-Process -Id $gitProc.Id -Force
-    Stop-Process -Id $pgProc.Id -Force
+    if ($gitProc -and -not $gitProc.HasExited) {
+        Stop-Process -Id $gitProc.Id -Force
+    }
+    if ($pgProc -and -not $pgProc.HasExited) {
+        Stop-Process -Id $pgProc.Id -Force
+    }
 }


### PR DESCRIPTION
## Summary
- validate provided menu paths in `test-menu.ps1`
- clean up test processes only if still running

## Testing
- `pwsh -File tests/test-servers.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6860e00cca588326a85b064cc0c173a5