### PR TITLE
Add port validation across scripts

### DIFF
--- a/execute-mcp-command.ps1
+++ b/execute-mcp-command.ps1
@@ -7,6 +7,18 @@ param (
 # Output what we're doing
 Write-Host "Executing MCP menu item: $menuPath"
 
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+$uri = "http://localhost:8001/mcp"
+$port = ([System.Uri]$uri).Port
+if (-not (Test-ValidPort -Port $port)) {
+    Write-Error "Invalid port: $port"
+    exit 1
+}
+
 # Form the JSON payload
 $payload = @{
     method = "execute_menu_item"

--- a/execute-mcp-message.ps1
+++ b/execute-mcp-message.ps1
@@ -7,6 +7,18 @@ param (
 # Output what we're doing
 Write-Host "Sending message to Unity: $message"
 
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+$uri = "http://localhost:8001/mcp"
+$port = ([System.Uri]$uri).Port
+if (-not (Test-ValidPort -Port $port)) {
+    Write-Error "Invalid port: $port"
+    exit 1
+}
+
 # Form the JSON payload
 $payload = @{
     method = "notify_message"

--- a/mcpWebSocketClient-advanced.ps1
+++ b/mcpWebSocketClient-advanced.ps1
@@ -30,6 +30,17 @@ param (
     [string]$serverUrl = "ws://localhost:8001/McpUnity"
 )
 
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+$parsedUri = [System.Uri]$serverUrl
+if (-not (Test-ValidPort -Port $parsedUri.Port)) {
+    Write-Host "Invalid port in -serverUrl parameter: $($parsedUri.Port)" -ForegroundColor Red
+    return
+}
+
 # Load required .NET assemblies
 Add-Type -AssemblyName System.Net.WebSockets
 Add-Type -AssemblyName System.Threading.Tasks

--- a/mcpWebSocketClient-simple.ps1
+++ b/mcpWebSocketClient-simple.ps1
@@ -10,6 +10,11 @@ param (
     [string]$logType = "Log"  # Can be: Log, Warning, Error
 )
 
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
 # Validate parameters
 if (!$menuPath -and !$message) {
     Write-Host "Error: You must provide either -menuPath or -message parameter"
@@ -26,6 +31,11 @@ try {
     # Create client WebSocket
     $client = New-Object System.Net.WebSockets.ClientWebSocket
     $uri = New-Object System.Uri("ws://localhost:8001/McpUnity")
+
+    if (-not (Test-ValidPort -Port $uri.Port)) {
+        Write-Host "Invalid port in WebSocket URI: $($uri.Port)" -ForegroundColor Red
+        return
+    }
     
     # Connect to the server
     $connectTask = $client.ConnectAsync($uri, [System.Threading.CancellationToken]::None)

--- a/run-git-server.ps1
+++ b/run-git-server.ps1
@@ -3,6 +3,17 @@ param(
     [string]$ServerPath
 )
 
+# Validate port number
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port: $Port. Must be between 1 and 65535."
+    exit 1
+}
+
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -8,6 +8,17 @@ param (
     [string]$ConfigFile = ".mcp-server-config.json"
 )
 
+# Validate port number
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port: $Port. Must be between 1 and 65535."
+    exit 1
+}
+
 # Load configuration from file if it exists
 $config = @{
     "port" = $Port

--- a/run-mcpproxy-server.ps1
+++ b/run-mcpproxy-server.ps1
@@ -1,6 +1,16 @@
 # PowerShell script to start the MCP Proxy server
 Write-Host "Starting MCP Proxy Server..."
 
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+if (-not (Test-ValidPort -Port 8004)) {
+    Write-Error "Invalid port: 8004. Must be between 1 and 65535."
+    exit 1
+}
+
 # Check if Node.js is available
 try {
     $nodeVersion = node --version

--- a/run-postgres-server.ps1
+++ b/run-postgres-server.ps1
@@ -3,6 +3,17 @@ param(
     [string]$ServerPath
 )
 
+# Validate port number
+function Test-ValidPort {
+    param([int]$Port)
+    return $Port -ge 1 -and $Port -le 65535
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port: $Port. Must be between 1 and 65535."
+    exit 1
+}
+
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition


### PR DESCRIPTION
## Summary
- add `Test-ValidPort` to validate ports in PowerShell scripts
- check port numbers for server launch scripts
- verify WebSocket clients use valid port numbers
- validate port usage in command and message scripts

## Testing
- `pwsh ./tests/test-servers.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6860e3efb7488326b61e4c9cda3e064d