### PR TITLE
Improve port validation error handling

### DIFF
--- a/run-git-server.ps1
+++ b/run-git-server.ps1
@@ -3,6 +3,15 @@ param(
     [string]$ServerPath
 )
 
+function Test-ValidPort {
+    param([int]$Port)
+    return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
+}
+
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -8,6 +8,16 @@ param (
     [string]$ConfigFile = ".mcp-server-config.json"
 )
 
+# Validate the supplied port number
+function Test-ValidPort {
+    param([int]$Port)
+    return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
+}
+
 # Load configuration from file if it exists
 $config = @{
     "port" = $Port

--- a/run-postgres-server.ps1
+++ b/run-postgres-server.ps1
@@ -3,6 +3,15 @@ param(
     [string]$ServerPath
 )
 
+function Test-ValidPort {
+    param([int]$Port)
+    return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
+}
+
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition

--- a/test-menu.ps1
+++ b/test-menu.ps1
@@ -11,9 +11,18 @@ param (
     [string[]]$MenuPaths,
     
     [int]$Port = 8001,
-    
+
     [switch]$Verbose
 )
+
+function Test-ValidPort {
+    param([int]$Port)
+    return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
+}
 
 # Import required modules
 Add-Type -AssemblyName System.Net.WebSockets.Client


### PR DESCRIPTION
## Summary
- use `-ErrorAction Stop` when validating port numbers
- re-run PowerShell-based server tests

## Testing
- `pwsh tests/test-servers.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6860e005ed1c83269d3688f9224b719b