### PR TITLE
Fix server test cleanup

### DIFF
--- a/mcpWebSocketClient-advanced.ps1
+++ b/mcpWebSocketClient-advanced.ps1
@@ -51,16 +51,13 @@ function Connect-ToWebSocket {
         $connection.Wait()
         
         if ($clientWebSocket.State -eq [System.Net.WebSockets.WebSocketState]::Open) {
-            Write-Host "True"
             Write-Host "WebSocket connected successfully"
             return $clientWebSocket
         } else {
-            Write-Host "False"
             Write-Host "Failed to connect to WebSocket. State: $($clientWebSocket.State)"
             return $null
         }
     } catch {
-        Write-Host "False"
         Write-Host "Error connecting to WebSocket: $_"
         return $null
     }
@@ -86,11 +83,9 @@ function Send-WebSocketMessage {
         )
         $sendTask.Wait()
         
-        Write-Host "True"
         Write-Host "Request sent successfully"
         return $true
     } catch {
-        Write-Host "False"
         Write-Host "Error sending message: $_"
         return $false
     }
@@ -137,7 +132,6 @@ function Close-WebSocketConnection {
                 [System.Threading.CancellationToken]::None
             )
             $closeTask.Wait()
-            Write-Host "True"
             Write-Host "WebSocket connection closed"
         } catch {
             Write-Host "Error closing WebSocket connection: $_"

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -21,6 +21,6 @@ try {
     $pgResponse = Invoke-WebRequest -Uri "http://localhost:$PostgresPort" -UseBasicParsing -TimeoutSec 5
     Write-Host "Postgres server responded: $($pgResponse.Content)"
 } finally {
-    Stop-Process -Id $gitProc.Id -Force
-    Stop-Process -Id $pgProc.Id -Force
+    Stop-Process -Id $gitProc.Id -Force -ErrorAction SilentlyContinue
+    Stop-Process -Id $pgProc.Id -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Summary
- ignore errors when terminating server processes in test script
- ensure `True`/`False` log lines are removed

## Testing
- `pwsh -NoLogo -File tests/test-servers.ps1 -GitPort 8091 -PostgresPort 8011`
- `pwsh -NoLogo -Command "Invoke-ScriptAnalyzer -Path mcpWebSocketClient-advanced.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6860e000d4d083269b07912450b38ab2