### PR TITLE
Ensure newline at EOF for key scripts

### DIFF
--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -206,4 +206,4 @@ if ($Monitor -and $processId) {
         # Clean up if script is interrupted
         Write-Host "Server monitoring stopped." -ForegroundColor Yellow
     }
-} 
+}

--- a/test-menu.ps1
+++ b/test-menu.ps1
@@ -291,4 +291,4 @@ if ($results.Failed -eq 0) {
 else {
     Write-Host "`n❌ Some menu items failed: $($results.Failed)/$($results.Total) failed" -ForegroundColor Red
     exit 1
-} 
+}

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -21,6 +21,12 @@ try {
     $pgResponse = Invoke-WebRequest -Uri "http://localhost:$PostgresPort" -UseBasicParsing -TimeoutSec 5
     Write-Host "Postgres server responded: $($pgResponse.Content)"
 } finally {
-    Stop-Process -Id $gitProc.Id -Force
-    Stop-Process -Id $pgProc.Id -Force
+    $gitRunning = Get-Process -Id $gitProc.Id -ErrorAction SilentlyContinue
+    if ($gitRunning) { Stop-Process -Id $gitProc.Id -Force }
+
+    $pgRunning = Get-Process -Id $pgProc.Id -ErrorAction SilentlyContinue
+    if ($pgRunning) { Stop-Process -Id $pgProc.Id -Force }
+
+    # Ensure child Node.js servers are terminated
+    Get-Process node -ErrorAction SilentlyContinue | Stop-Process -Force
 }


### PR DESCRIPTION
## Summary
- add trailing newline to `run-mcp-server.ps1`
- add trailing newline to `test-menu.ps1`
- improve cleanup logic in server tests

## Testing
- `pwsh tests/test-servers.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6860e3ee186c8326bc8e1f6137f42b7c