### PR TITLE
Fix proxy directory change error handling

### DIFF
--- a/run-mcpproxy-server.ps1
+++ b/run-mcpproxy-server.ps1
@@ -5,17 +5,21 @@ Write-Host "Starting MCP Proxy Server..."
 try {
     $nodeVersion = node --version
     Write-Host "Using Node.js $nodeVersion"
-}
-catch {
+} catch {
     Write-Error "Node.js not found. Please install Node.js 18+ to run the MCP Proxy server."
     exit 1
 }
 
 # Change to the mcpProxy server directory
-Set-Location -Path "C:\Users\w1n51\mcpProxy"
+try {
+    Set-Location -Path "C:\Users\w1n51\mcpProxy"
+} catch {
+    Write-Error "Unable to change directory"
+    exit 1
+}
 
 # Start the mcpProxy server as a background job
 Start-Process node -ArgumentList "dist/src/index.js" -NoNewWindow -PassThru
 
 Write-Host "MCP Proxy Server started on port 8004"
-Write-Host "Server will run in the background. To stop, close the Node.js process." 
+Write-Host "Server will run in the background. To stop, close the Node.js process."

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -6,11 +6,15 @@ param(
 $scriptDir = $PSScriptRoot
 $root = Split-Path -Parent $scriptDir
 
-$gitScript = Join-Path $root 'run-git-server.ps1'
-$pgScript  = Join-Path $root 'run-postgres-server.ps1'
+$gitServer = Join-Path $root 'servers/git/index.js'
+$pgServer  = Join-Path $root 'servers/postgres/index.js'
 
-$gitProc = Start-Process -FilePath pwsh -ArgumentList '-File', $gitScript, '-Port', $GitPort -PassThru
-$pgProc  = Start-Process -FilePath pwsh -ArgumentList '-File', $pgScript, '-Port', $PostgresPort -PassThru
+$gitProc = Start-Process node -ArgumentList $gitServer -NoNewWindow -PassThru -Environment @{
+    'PORT' = $GitPort
+}
+$pgProc  = Start-Process node -ArgumentList $pgServer -NoNewWindow -PassThru -Environment @{
+    'PORT' = $PostgresPort
+}
 
 Start-Sleep -Seconds 2
 


### PR DESCRIPTION
## Summary
- fix stray text and newline in `run-mcpproxy-server.ps1`
- keep try/catch around changing to `mcpProxy`
- update `test-servers.ps1` to use Node directly

## Testing
- `pwsh -File tests/test-servers.ps1`
- `Invoke-ScriptAnalyzer -Path run-mcpproxy-server.ps1`
- `Invoke-ScriptAnalyzer -Path tests/test-servers.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6860e00671488326ba0c5111a9dae0a2