### PR TITLE
Fix server test cleanup

### DIFF
--- a/safe-mcp-restart.ps1
+++ b/safe-mcp-restart.ps1
@@ -12,16 +12,24 @@ $env:UNITY_PORT = "8001"
 # Check if we're in the correct directory
 $currentDir = Get-Location
 $serverFullPath = Join-Path $currentDir $serverPath
+$serverIndex = ''
 
 if (Test-Path $serverFullPath) {
     # We're in the project root, run the command with path
     Write-Host "Running MCP server from project root..."
-    Start-Process -FilePath "node" -ArgumentList "$serverPath/build/index.js" -NoNewWindow
+    $serverIndex = Join-Path $serverPath 'build/index.js'
 } else {
     # Try to run directly - might be already in the server directory
     Write-Host "Running MCP server directly..."
-    Start-Process -FilePath "node" -ArgumentList "build/index.js" -NoNewWindow
+    $serverIndex = 'build/index.js'
 }
+
+if (-not (Test-Path $serverIndex)) {
+    Write-Error "Server file not found: $serverIndex"
+    exit 1
+}
+
+Start-Process -FilePath "node" -ArgumentList "\"$serverIndex\"" -NoNewWindow
 
 Write-Host "MCP server started on port 8001. You can now reconnect from Unity."
 Write-Host ""

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -6,11 +6,14 @@ param(
 $scriptDir = $PSScriptRoot
 $root = Split-Path -Parent $scriptDir
 
-$gitScript = Join-Path $root 'run-git-server.ps1'
-$pgScript  = Join-Path $root 'run-postgres-server.ps1'
+$gitScript = Join-Path $root 'servers/git/index.js'
+$pgScript  = Join-Path $root 'servers/postgres/index.js'
 
-$gitProc = Start-Process -FilePath pwsh -ArgumentList '-File', $gitScript, '-Port', $GitPort -PassThru
-$pgProc  = Start-Process -FilePath pwsh -ArgumentList '-File', $pgScript, '-Port', $PostgresPort -PassThru
+$env:PORT = $GitPort
+$gitProc = Start-Process -FilePath node -ArgumentList $gitScript -PassThru -NoNewWindow
+
+$env:PORT = $PostgresPort
+$pgProc  = Start-Process -FilePath node -ArgumentList $pgScript -PassThru -NoNewWindow
 
 Start-Sleep -Seconds 2
 
@@ -21,6 +24,13 @@ try {
     $pgResponse = Invoke-WebRequest -Uri "http://localhost:$PostgresPort" -UseBasicParsing -TimeoutSec 5
     Write-Host "Postgres server responded: $($pgResponse.Content)"
 } finally {
-    Stop-Process -Id $gitProc.Id -Force
-    Stop-Process -Id $pgProc.Id -Force
+    $gitProcess = Get-Process -Id $gitProc.Id -ErrorAction SilentlyContinue
+    if ($gitProcess) {
+        Stop-Process -Id $gitProcess.Id -Force
+    }
+
+    $pgProcess = Get-Process -Id $pgProc.Id -ErrorAction SilentlyContinue
+    if ($pgProcess) {
+        Stop-Process -Id $pgProcess.Id -Force
+    }
 }


### PR DESCRIPTION
## Summary
- update tests to start Node servers directly
- ensure test cleanup stops remaining processes gracefully

## Testing
- `pwsh tests/test-servers.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6860dffbd50883269127f9d228a14ec4