### PR TITLE
Update config updater with workspace parameter

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -111,10 +111,11 @@ The MCP Unity server is configured in the `~/.cursor/mcp.json` file:
 }
 ```
 
-You can update this configuration using the provided script:
+You can update this configuration using the provided script. Provide the
+workspace path for the Unity fallback server with the `-Workspace` parameter:
 
 ```powershell
-./update-mcp-config.ps1
+./update-mcp-config.ps1 -Workspace "C:/path/to/TBD SpaceGame"
 ```
 
 ## Tools

--- a/update-mcp-config.ps1
+++ b/update-mcp-config.ps1
@@ -1,28 +1,31 @@
 # update-mcp-config.ps1
 # Purpose: Update the fallback server workspace path in the MCP config file
-# Usage: .\update-mcp-config.ps1 [-ConfigPath <path>]
+# Usage: .\update-mcp-config.ps1 [-ConfigPath <path>] [-Workspace <path>]
 
 param(
-    [string]$ConfigPath = "C:\Users\w1n51\.cursor\mcp.json"
+    [string]$ConfigPath = (Join-Path $Env:USERPROFILE '.cursor/mcp.json'),
+    [Parameter(Mandatory=$true)]
+    [string]$Workspace
 )
 
-# Check if the file exists
-if (Test-Path $ConfigPath) {
-    Write-Host "Found MCP configuration at $ConfigPath"
-
-    # Read the current configuration
-    $config = Get-Content -Path $ConfigPath -Raw | ConvertFrom-Json
-
-    # Update the fallback server workspace path
-    $config.mcpServers."mcp-unity-fallback".workspace = "C:/Users/w1n51/OneDrive/Desktop/Gamedev/TBD Space Game/TBD SpaceGame/TBD SpaceGame"
-
-    # Convert back to JSON and save
-    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $ConfigPath
-
-    Write-Host "Updated mcp-unity-fallback workspace path successfully"
-} else {
+# Validate the configuration file exists
+if (-not (Test-Path $ConfigPath)) {
     Write-Host "MCP configuration file not found at $ConfigPath"
+    return
 }
+
+Write-Host "Found MCP configuration at $ConfigPath"
+
+# Read the current configuration
+$config = Get-Content -Path $ConfigPath -Raw | ConvertFrom-Json
+
+# Update the fallback server workspace path
+$config.mcpServers."mcp-unity-fallback".workspace = $Workspace
+
+# Convert back to JSON and save
+$config | ConvertTo-Json -Depth 10 | Set-Content -Path $ConfigPath
+
+Write-Host "Updated mcp-unity-fallback workspace path successfully"
 
 # Output the current configuration
 Write-Host "Current MCP Configuration:"


### PR DESCRIPTION
## Summary
- add `-Workspace` parameter to `update-mcp-config.ps1`
- build default config path using `$Env:USERPROFILE`
- validate config file existence before updating
- document the new parameter in the README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869f015e1108326b85b98fe145ac04a