### PR TITLE
Add ProxyPath option to MCP proxy script

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -67,8 +67,11 @@ Manages database operations through MCP.
 Routes requests to appropriate MCP servers.
 
 ```powershell
-# Start the MCP Proxy server
+# Start the MCP Proxy server (defaults to a path relative to this repo)
 ./run-mcpproxy-server.ps1
+
+# Provide a custom proxy path if needed
+./run-mcpproxy-server.ps1 -ProxyPath "C:\path\to\mcpProxy"
 ```
 
 ### All Servers

--- a/run-mcpproxy-server.ps1
+++ b/run-mcpproxy-server.ps1
@@ -1,5 +1,19 @@
+
+param(
+    [string]$ProxyPath
+)
+
 # PowerShell script to start the MCP Proxy server
 Write-Host "Starting MCP Proxy Server..."
+
+$scriptDir = $PSScriptRoot
+if (-not $scriptDir) {
+    $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (-not $ProxyPath) {
+    # Default to the "servers/mcpProxy" directory relative to this script
+    $ProxyPath = Join-Path $scriptDir 'servers/mcpProxy'
+}
 
 function Test-ValidPort {
     param([int]$Port)
@@ -22,7 +36,7 @@ try {
 
 # Change to the mcpProxy server directory
 try {
-    Set-Location -Path "C:\Users\w1n51\mcpProxy"
+    Set-Location -Path $ProxyPath
 } catch {
     Write-Error "Unable to change directory"
     exit 1


### PR DESCRIPTION
## Summary
- add `-ProxyPath` parameter for `run-mcpproxy-server.ps1`
- default proxy path relative to `$PSScriptRoot`
- update documentation with optional parameter example

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869f011ba40832680d57a7cb0fc0762