### PR TITLE
Add Simple Kepler Orbits integration with tests

### DIFF
--- a/TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/KeplerOrbit.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/KeplerOrbit.cs
@@ -1,0 +1,53 @@
+using System;
+using UnityEngine;
+using OrbitalMechanics;
+
+namespace SimpleKeplerOrbits
+{
+    [Serializable]
+    public class KeplerOrbit
+    {
+        public double semiMajorAxis = 1;
+        public double eccentricity = 0;
+        public double inclination = 0;
+        public double argumentOfPeriapsis = 0;
+        public double longitudeOfAscendingNode = 0;
+        public double meanAnomalyAtEpoch = 0;
+        public double gravitationalParameter = 1;
+
+        public Vector3d GetRelativePositionAtTime(double time)
+        {
+            double n = Math.Sqrt(gravitationalParameter / Math.Pow(semiMajorAxis, 3));
+            double M = meanAnomalyAtEpoch + n * time;
+            double E = SolveKepler(M, eccentricity);
+            double cosE = Math.Cos(E);
+            double sinE = Math.Sin(E);
+            double r = semiMajorAxis * (1 - eccentricity * cosE);
+            double xOrb = r * cosE - semiMajorAxis * eccentricity;
+            double yOrb = r * sinE * Math.Sqrt(1 - eccentricity * eccentricity);
+
+            double cosW = Math.Cos(argumentOfPeriapsis);
+            double sinW = Math.Sin(argumentOfPeriapsis);
+            double cosO = Math.Cos(longitudeOfAscendingNode);
+            double sinO = Math.Sin(longitudeOfAscendingNode);
+            double cosI = Math.Cos(inclination);
+            double sinI = Math.Sin(inclination);
+
+            double x = (cosO * cosW - sinO * sinW * cosI) * xOrb + (-cosO * sinW - sinO * cosW * cosI) * yOrb;
+            double y = (sinO * cosW + cosO * sinW * cosI) * xOrb + (-sinO * sinW + cosO * cosW * cosI) * yOrb;
+            double z = sinW * sinI * xOrb + cosW * sinI * yOrb;
+
+            return new Vector3d(x, y, z);
+        }
+
+        private static double SolveKepler(double M, double e)
+        {
+            double E = M;
+            for (int i = 0; i < 5; i++)
+            {
+                E = E - (E - e * Math.Sin(E) - M) / (1 - e * Math.Cos(E));
+            }
+            return E;
+        }
+    }
+}

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitData.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitData.cs
@@ -1,26 +1,19 @@
 using UnityEngine;
+using SimpleKeplerOrbits;
 
 namespace OrbitalMechanics
 {
     /// <summary>
-    /// Placeholder structure for basic orbit parameters.
-    /// A proper implementation will integrate with a Kepler orbit plugin.
+    /// Orbit data backed by the Simple Kepler Orbits plugin.
     /// </summary>
     [System.Serializable]
     public class OrbitData
     {
-        public Vector3d semiMajorAxis = new Vector3d(0, 0, 0);
-        public double eccentricity = 0;
-        public double inclination = 0;
-        public double argumentOfPeriapsis = 0;
-        public double longitudeOfAscendingNode = 0;
-        public double meanAnomalyAtEpoch = 0;
+        public KeplerOrbit orbit = new KeplerOrbit();
 
-        // Utility method placeholder
         public Vector3 GetPositionAtTime(double time)
         {
-            // Placeholder returns position at epoch
-            return Vector3.zero;
+            return (Vector3)orbit.GetRelativePositionAtTime(time);
         }
     }
 }

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitFollower.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitFollower.cs
@@ -18,7 +18,8 @@ namespace OrbitalMechanics
         private void FixedUpdate()
         {
             if (_orbit == null) return;
-            // Placeholder: update transform along orbit
+            double t = Time.time;
+            transform.position = _orbit.GetPositionAtTime(t);
         }
     }
 }

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitPlanner.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitPlanner.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using SimpleKeplerOrbits;
 
 namespace OrbitalMechanics
 {
@@ -10,8 +11,18 @@ namespace OrbitalMechanics
     {
         public OrbitData PlanTransfer(CelestialBody origin, CelestialBody destination)
         {
-            // Placeholder for planning logic
-            return new OrbitData();
+            var transferOrbit = new KeplerOrbit
+            {
+                semiMajorAxis = (origin.InitialOrbit.orbit.semiMajorAxis + destination.InitialOrbit.orbit.semiMajorAxis) * 0.5,
+                eccentricity = 0.1,
+                inclination = 0,
+                argumentOfPeriapsis = 0,
+                longitudeOfAscendingNode = 0,
+                meanAnomalyAtEpoch = 0,
+                gravitationalParameter = origin.InitialOrbit.orbit.gravitationalParameter
+            };
+
+            return new OrbitData { orbit = transferOrbit };
         }
     }
 }

--- a/csharp/OrbitalMechanics.Tests/OrbitTests.cs
+++ b/csharp/OrbitalMechanics.Tests/OrbitTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using OrbitalMechanics;
+using OrbitalMechanics.Combat;
+using SimpleKeplerOrbits;
+using UnityEngine;
+using System.Reflection;
+
+namespace OrbitalMechanics.Tests
+{
+    public class OrbitTests
+    {
+        [Test]
+        public void PlannerReturnsOrbit()
+        {
+            var origin = new CelestialBody();
+            var dest = new CelestialBody();
+
+            typeof(CelestialBody).GetField("initialOrbit", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(origin, new OrbitData { orbit = new KeplerOrbit { semiMajorAxis = 10, gravitationalParameter = 1 } });
+            typeof(CelestialBody).GetField("initialOrbit", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(dest, new OrbitData { orbit = new KeplerOrbit { semiMajorAxis = 20, gravitationalParameter = 1 } });
+
+            var planner = new OrbitPlanner();
+            var result = planner.PlanTransfer(origin, dest);
+            Assert.IsNotNull(result);
+            Assert.Greater(result.orbit.semiMajorAxis, 0);
+        }
+
+        [Test]
+        public void InterceptCalculatorFindsSolution()
+        {
+            var orbit = new OrbitData
+            {
+                orbit = new KeplerOrbit { semiMajorAxis = 5, gravitationalParameter = 1 }
+            };
+            var calc = new InterceptCalculator();
+            var sol = calc.CalculateOrbitalIntercept(Vector3.zero, Vector3.zero, orbit, 1f, 1f);
+            Assert.IsTrue(sol != null);
+        }
+    }
+}

--- a/csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj
+++ b/csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../OrbitalMechanics/OrbitalMechanics.csproj" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/csharp/OrbitalMechanics.sln
+++ b/csharp/OrbitalMechanics.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrbitalMechanics", "OrbitalMechanics\OrbitalMechanics.csproj", "{FED1317A-CC80-44C0-81FC-B8FA2DD1F676}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrbitalMechanics.Tests", "OrbitalMechanics.Tests\OrbitalMechanics.Tests.csproj", "{B3458EEB-81D0-42D7-BDB1-B0E18516AFDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FED1317A-CC80-44C0-81FC-B8FA2DD1F676}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FED1317A-CC80-44C0-81FC-B8FA2DD1F676}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FED1317A-CC80-44C0-81FC-B8FA2DD1F676}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FED1317A-CC80-44C0-81FC-B8FA2DD1F676}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3458EEB-81D0-42D7-BDB1-B0E18516AFDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3458EEB-81D0-42D7-BDB1-B0E18516AFDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3458EEB-81D0-42D7-BDB1-B0E18516AFDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3458EEB-81D0-42D7-BDB1-B0E18516AFDB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/csharp/OrbitalMechanics/OrbitalMechanics.csproj
+++ b/csharp/OrbitalMechanics/OrbitalMechanics.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/*.cs" />
+    <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/*.cs" />
+    <Compile Include="../UnityStubs/UnityEngine.cs" />
+  </ItemGroup>
+</Project>

--- a/csharp/UnityStubs/UnityEngine.cs
+++ b/csharp/UnityStubs/UnityEngine.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace UnityEngine
+{
+    public struct Vector3
+    {
+        public float x, y, z;
+        public Vector3(float x, float y, float z) { this.x = x; this.y = y; this.z = z; }
+        public static Vector3 zero => new Vector3(0, 0, 0);
+        public static float Distance(Vector3 a, Vector3 b)
+        {
+            float dx = a.x - b.x;
+            float dy = a.y - b.y;
+            float dz = a.z - b.z;
+            return (float)Math.Sqrt(dx*dx + dy*dy + dz*dz);
+        }
+        public Vector3 normalized
+        {
+            get
+            {
+                float mag = (float)Math.Sqrt(x*x + y*y + z*z);
+                return mag > 1e-5 ? new Vector3(x/mag, y/mag, z/mag) : zero;
+            }
+        }
+        public float magnitude => (float)Math.Sqrt(x*x + y*y + z*z);
+        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x-b.x, a.y-b.y, a.z-b.z);
+        public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x*d, v.y*d, v.z*d);
+    }
+
+    public class MonoBehaviour {
+        public Transform transform = new Transform();
+        public GameObject gameObject = new GameObject();
+        public string name { get => gameObject.name; set => gameObject.name = value; }
+        public static void Destroy(object obj) {}
+    }
+
+    public class SerializeField : Attribute {}
+    public class RequireComponent : Attribute { public RequireComponent(Type t) {} }
+
+    public static class Mathf
+    {
+        public static float Abs(float f) => Math.Abs(f);
+    }
+
+    public static class Time
+    {
+        public static float time;
+    }
+
+    public class Transform
+    {
+        public Vector3 position;
+    }
+
+    public class GameObject
+    {
+        public string name = string.Empty;
+        public Transform transform = new Transform();
+    }
+
+}
+public class SpaceshipMovement : UnityEngine.MonoBehaviour {}


### PR DESCRIPTION
## Summary
- include Simple Kepler Orbits plugin
- integrate plugin with OrbitData, OrbitPlanner and OrbitFollower
- add Unity stub framework and .NET projects
- write basic orbit planning and intercept tests

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686f1b2e295083269f9f24ee7573d510