### PR TITLE
Add generation and timestamp to Crew save data

### DIFF
--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewManager.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -11,6 +12,8 @@ namespace Crew
     public class CrewManager : MonoBehaviour
     {
         public List<CrewMember> activeCrew = new();
+        public int generation;
+        public string lastSaveTimestamp = string.Empty;
 
         /// <summary>
         /// Add a crew member to the active roster.
@@ -36,10 +39,22 @@ namespace Crew
 
         /// <summary>
         /// Save the current crew roster to a JSON file.
+        /// Example structure:
+        /// {
+        ///   "crew": [ ... ],
+        ///   "generation": 3,
+        ///   "timestamp": "2024-01-01T00:00:00Z"
+        /// }
         /// </summary>
         public void SaveToFile(string path)
         {
-            var container = new CrewContainer { crew = activeCrew };
+            lastSaveTimestamp = DateTime.UtcNow.ToString("o");
+            var container = new CrewContainer
+            {
+                crew = activeCrew,
+                generation = generation,
+                timestamp = lastSaveTimestamp
+            };
             string json = JsonUtility.ToJson(container, true);
             File.WriteAllText(path, json);
         }
@@ -57,13 +72,24 @@ namespace Crew
 
             string json = File.ReadAllText(path);
             var container = JsonUtility.FromJson<CrewContainer>(json);
-            activeCrew = container != null ? container.crew : new List<CrewMember>();
+            if (container != null)
+            {
+                activeCrew = container.crew ?? new List<CrewMember>();
+                generation = container.generation;
+                lastSaveTimestamp = container.timestamp;
+            }
+            else
+            {
+                activeCrew = new List<CrewMember>();
+            }
         }
 
         [System.Serializable]
         private class CrewContainer
         {
             public List<CrewMember> crew = new();
+            public int generation;
+            public string timestamp = string.Empty;
 
         }
     }


### PR DESCRIPTION
## Summary
- extend `CrewManager` save/load to persist generation and timestamp
- document example save data JSON format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f2fe413388326821812707c7f5824