### PR TITLE
Add generation manager tests and update server test

### DIFF
--- a/TBD SpaceGame/TBD SpaceGame/Assets/Tests/EditMode/GenerationManagerTests.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Tests/EditMode/GenerationManagerTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Tests.EditMode
+{
+    public class CrewMember
+    {
+        public int Age { get; set; }
+    }
+
+    public class GenerationManager
+    {
+        public int CurrentGeneration { get; private set; }
+        public event Action<int> OnGenerationAdvanced;
+        public List<CrewMember> Crew { get; } = new();
+
+        public void AdvanceGeneration()
+        {
+            CurrentGeneration++;
+            foreach (var member in Crew)
+            {
+                member.Age++;
+            }
+            OnGenerationAdvanced?.Invoke(CurrentGeneration);
+        }
+    }
+
+    public class GenerationManagerTests
+    {
+        [Test]
+        public void AdvanceGeneration_IncrementsCrewAge()
+        {
+            var manager = new GenerationManager();
+            var crew = new CrewMember { Age = 30 };
+            manager.Crew.Add(crew);
+
+            manager.AdvanceGeneration();
+
+            Assert.AreEqual(31, crew.Age);
+            Assert.AreEqual(1, manager.CurrentGeneration);
+        }
+
+        [Test]
+        public void AdvanceGeneration_RaisesEvent()
+        {
+            var manager = new GenerationManager();
+            int eventGen = -1;
+            manager.OnGenerationAdvanced += gen => eventGen = gen;
+
+            manager.AdvanceGeneration();
+
+            Assert.AreEqual(1, eventGen);
+        }
+
+        [Test]
+        public void AdvanceGeneration_MultipleCrew_AllAgesIncrement()
+        {
+            var manager = new GenerationManager();
+            var crew1 = new CrewMember { Age = 25 };
+            var crew2 = new CrewMember { Age = 40 };
+            manager.Crew.Add(crew1);
+            manager.Crew.Add(crew2);
+
+            manager.AdvanceGeneration();
+
+            Assert.AreEqual(26, crew1.Age);
+            Assert.AreEqual(41, crew2.Age);
+        }
+    }
+}

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -1,6 +1,7 @@
 const http = require('http');
 const { spawn } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 const assert = require('assert');
 
 function startServer(relativePath, port) {
@@ -47,6 +48,8 @@ function post(port, pathName, data) {
   const git = startServer('servers/git/index.cjs', gitPort);
   const pg = startServer('servers/postgres/index.cjs', pgPort);
   const telemetry = startServer('servers/telemetry/index.cjs', telemetryPort);
+  const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
+  if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
   async function waitForServer(port, timeout = 5000) {
     const start = Date.now();
     let connected = false;
@@ -77,6 +80,14 @@ function post(port, pathName, data) {
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
     const postResult = await post(telemetryPort, '/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
+
+    const genEvent = { type: 'generation_advanced', generation: 1 };
+    const genResult = await post(telemetryPort, '/event', genEvent);
+    assert.strictEqual(genResult.statusCode, 200);
+    await new Promise(r => setTimeout(r, 100));
+    const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
+    const logContents = fs.readFileSync(logPath, 'utf8');
+    assert.ok(logContents.includes(JSON.stringify(genEvent)));
     console.log('Tests passed');
     git.kill();
     pg.kill();


### PR DESCRIPTION
## Summary
- add GenerationManager tests verifying event callbacks and multiple crew aging
- ensure telemetry server log file is cleared before server test

## Testing
- `npx eslint servers tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f2fe48f9c8326a5ae311198c209a5