### PR TITLE
Add generation stats accessor

### DIFF
--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewMember.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewMember.cs
@@ -10,6 +10,7 @@ namespace Crew
     public class CrewMember
     {
         public string role;
+        public int age;
         public List<string> traits = new();
         public float health = 100f;
         public float morale = 100f;

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/GenerationManager.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/GenerationManager.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Crew
+{
+    /// <summary>
+    /// Handles long duration time skips and generational changes for the crew.
+    /// </summary>
+    public class GenerationManager : MonoBehaviour
+    {
+        public event Action<TimeSpan> OnTimeSkipRequested;
+        public event Action<int> OnGenerationAdvanced;
+        public event Action OnTimeSkipCompleted;
+
+        public CrewManager crewManager;
+
+        private readonly List<int> populationHistory = new();
+        private TimeSpan _pendingSkip;
+        private int _currentGeneration = 1;
+
+        /// <summary>
+        /// Represents basic generational statistics.
+        /// </summary>
+        public struct GenerationStats
+        {
+            public int generation;
+            public int population;
+        }
+
+        /// <summary>
+        /// Get statistics for the current generation.
+        /// </summary>
+        public GenerationStats CurrentStats
+        {
+            get
+            {
+                return new GenerationStats
+                {
+                    generation = _currentGeneration,
+                    population = crewManager != null ? crewManager.activeCrew.Count : 0
+                };
+            }
+        }
+
+        /// <summary>
+        /// Request that the simulation advance by the given duration.
+        /// </summary>
+        public void RequestTimeSkip(TimeSpan duration)
+        {
+            _pendingSkip = duration;
+            OnTimeSkipRequested?.Invoke(duration);
+            ProcessTimeSkip();
+        }
+
+        /// <summary>
+        /// Processes the previously requested time skip, ageing crew and spawning new generations.
+        /// </summary>
+        public void ProcessTimeSkip()
+        {
+            if (crewManager == null) return;
+
+            double years = _pendingSkip.TotalDays / 365.0;
+            int wholeYears = (int)Math.Floor(years);
+
+            for (int i = crewManager.activeCrew.Count - 1; i >= 0; i--)
+            {
+                CrewMember member = crewManager.activeCrew[i];
+                member.age += wholeYears;
+                if (member.age >= 80)
+                {
+                    crewManager.Remove(member);
+                }
+            }
+
+            for (int b = 0; b < wholeYears; b++)
+            {
+                crewManager.Recruit(new CrewMember { role = "Child", age = 0 });
+            }
+
+            populationHistory.Add(crewManager.activeCrew.Count);
+            _currentGeneration++;
+            OnGenerationAdvanced?.Invoke(_currentGeneration);
+            OnTimeSkipCompleted?.Invoke();
+        }
+
+        /// <summary>
+        /// Get the recorded population count for each completed generation.
+        /// </summary>
+        public IReadOnlyList<int> GetPopulationHistory()
+        {
+            return populationHistory.AsReadOnly();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend GenerationManager with struct for generation stats and history access
- keep crew aging logic that handles births and deaths
- ensure dependencies installed so tests pass

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f2fe181708326a0216b2893cedb64