### PR TITLE
Integrate GenerationManager with crew events

### DIFF
--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewManager.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/CrewManager.cs
@@ -10,28 +10,74 @@ namespace Crew
     /// </summary>
     public class CrewManager : MonoBehaviour
     {
+        [SerializeField] private GenerationManager generationManager;
         public List<CrewMember> activeCrew = new();
+
+        private void Awake()
+        {
+            if (generationManager == null)
+            {
+                generationManager = FindObjectOfType<GenerationManager>();
+            }
+
+            if (generationManager != null)
+            {
+                generationManager.OnCrewBorn += OnCrewBorn;
+                generationManager.OnCrewDied += OnCrewDied;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (generationManager != null)
+            {
+                generationManager.OnCrewBorn -= OnCrewBorn;
+                generationManager.OnCrewDied -= OnCrewDied;
+            }
+        }
 
         /// <summary>
         /// Add a crew member to the active roster.
+        /// The optional <paramref name="fromBirth"/> flag is used when
+        /// the member was born during a time skip.
         /// </summary>
-        public void Recruit(CrewMember member)
+        public void Recruit(CrewMember member, bool fromBirth = false)
         {
             if (member != null && !activeCrew.Contains(member))
             {
                 activeCrew.Add(member);
+                if (!fromBirth)
+                {
+                    generationManager?.Birth(member);
+                }
             }
         }
 
         /// <summary>
         /// Remove a crew member from the active roster.
+        /// The optional <paramref name="naturalDeath"/> flag indicates the
+        /// removal is due to natural causes during a time skip.
         /// </summary>
-        public void Remove(CrewMember member)
+        public void Remove(CrewMember member, bool naturalDeath = false)
         {
             if (member != null)
             {
                 activeCrew.Remove(member);
+                if (!naturalDeath)
+                {
+                    generationManager?.NaturalDeath(member);
+                }
             }
+        }
+
+        private void OnCrewBorn(CrewMember member)
+        {
+            Recruit(member, true);
+        }
+
+        private void OnCrewDied(CrewMember member)
+        {
+            Remove(member, true);
         }
 
         /// <summary>

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/GenerationManager.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/Crew/GenerationManager.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Crew
+{
+    /// <summary>
+    /// Handles generational progression and exposes events for births and natural deaths.
+    /// This is a minimal placeholder so other systems can react to population changes.
+    /// </summary>
+    public class GenerationManager : MonoBehaviour
+    {
+        public event Action<CrewMember> OnCrewBorn;
+        public event Action<CrewMember> OnCrewDied;
+
+        /// <summary>
+        /// Invoke when a new crew member is born.
+        /// </summary>
+        public void Birth(CrewMember member)
+        {
+            OnCrewBorn?.Invoke(member);
+        }
+
+        /// <summary>
+        /// Invoke when a crew member dies of natural causes.
+        /// </summary>
+        public void NaturalDeath(CrewMember member)
+        {
+            OnCrewDied?.Invoke(member);
+        }
+
+        /// <summary>
+        /// Simulate a time skip by processing births and deaths.
+        /// </summary>
+        public void ProcessTimeSkip(List<CrewMember> births, List<CrewMember> deaths)
+        {
+            foreach (var birth in births)
+            {
+                Birth(birth);
+            }
+
+            foreach (var death in deaths)
+            {
+                NaturalDeath(death);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refine CrewManager integration with GenerationManager
- automatically find GenerationManager if not assigned
- invoke GenerationManager methods for manual recruit/removal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f2fe23ffc83268c7f77c5554d06ab