### PR TITLE
Add Godot project and glTF export

### DIFF
--- a/Godot/TBDSpaceRPG.csproj
+++ b/Godot/TBDSpaceRPG.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Godot.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -1,0 +1,7 @@
+; Engine configuration file
+
+[application]
+config/name="TBDSpaceRPG"
+
+[dotnet]
+project="TBDSpaceRPG.csproj"

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -439,3 +439,11 @@ This workflow verifies that menu items are found, commands are executed, and the
 
 - [MCP Unity Package Documentation](https://github.com/gamelovers/mcp-unity)
 - [Unity Editor Scripting Manual](https://docs.unity3d.com/Manual/ExtendingTheEditor.html) 
+## Godot Integration
+
+To import exported assets into Godot:
+1. Copy or move the contents of `Assets_glTF/` into the `Godot` project folder.
+2. Open the Godot project in the Godot 4 editor.
+3. Each `.gltf` file will automatically generate a scene that can be instanced in your C# scripts.
+
+

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Editor/ExportToGltf.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Editor/ExportToGltf.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using UnityEditor;
+using UnityEditor.Formats.GLTF;
+using UnityEngine;
+
+public static class ExportToGltf
+{
+    [MenuItem("Tools/Export All To glTF")]
+    public static void ExportAll()
+    {
+        string targetDir = Path.Combine(Application.dataPath, "..", "..", "Assets_glTF");
+        if (!Directory.Exists(targetDir))
+        {
+            Directory.CreateDirectory(targetDir);
+        }
+
+        foreach (var scene in EditorBuildSettings.scenes)
+        {
+            if (!scene.enabled) continue;
+            string sceneName = Path.GetFileNameWithoutExtension(scene.path);
+            string path = Path.Combine(targetDir, sceneName + ".gltf");
+            var exporter = new GLTFSceneExporter(new[] { scene.path });
+            exporter.SaveGLTF(path);
+        }
+
+        string[] prefabs = AssetDatabase.FindAssets("t:Prefab");
+        foreach (string guid in prefabs)
+        {
+            string prefabPath = AssetDatabase.GUIDToAssetPath(guid);
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefab == null) continue;
+            string fileName = Path.GetFileNameWithoutExtension(prefabPath) + ".gltf";
+            string path = Path.Combine(targetDir, fileName);
+            var exporter = new GLTFSceneExporter(new[] { prefab });
+            exporter.SaveGLTF(path);
+        }
+
+        AssetDatabase.Refresh();
+        Debug.Log($"Exported glTF files to {targetDir}");
+    }
+}

--- a/TBD SpaceGame/TBD SpaceGame/Packages/manifest.json
+++ b/TBD SpaceGame/TBD SpaceGame/Packages/manifest.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "com.unity.formats.gltf": "2.1.3"
+  }
+}


### PR DESCRIPTION
## Summary
- create minimal Godot 4 project with C# support
- add Unity editor script to export scenes and prefabs to `Assets_glTF`
- add Unity package manifest with glTF exporter dependency
- document how to import the glTF assets into Godot

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871c9e04fa88326a3fc81af1c1fdbd3