### PR TITLE
Add KSA adapter placeholder and config

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -24,6 +24,7 @@ The TBD Space Game uses MCP (Model Context Protocol) to enable AI-assisted devel
 - **Server-Git**: Version control operations via MCP running on port 8080
 - **Server-Postgres**: Database operations via MCP running on port 8003
 - **MCPProxy**: Routes requests to appropriate MCP servers running on port 8004
+- **KSA Adapter**: Placeholder server for the upcoming KSA engine on port 8005
 
 These servers enable AI tools to interact with the Unity project, perform version control operations, manage database records, and more.
 
@@ -76,6 +77,18 @@ Routes requests to appropriate MCP servers.
 # Provide a custom proxy path if needed
 ./run-mcpproxy-server.ps1 -ProxyPath "C:\path\to\mcpProxy"
 ```
+
+### KSA Adapter
+
+Placeholder adapter for the upcoming KSA engine. It simply echoes MCP requests.
+
+```powershell
+# Start the KSA adapter
+./run-ksa-server.ps1
+```
+
+When the real engine API is available, replace the placeholder server with the
+actual implementation and update configuration values accordingly.
 
 ### All Servers
 
@@ -265,6 +278,7 @@ Log files are available in the following locations:
 - Server-Postgres: `servers/postgres/logs`
 - Telemetry Server: `servers/telemetry/logs`
 - MCPProxy: Terminal output only
+- KSA Adapter: Terminal output only
 
 ## Future Enhancements
 
@@ -275,6 +289,7 @@ Planned enhancements for the MCP integration:
 3. **Telemetry Collection**: Implemented telemetry server under `servers/telemetry`
 4. **Enhanced Documentation**: Interactive API documentation for all MCP servers
 5. **Visual MCP Tool**: GUI interface for interacting with MCP servers
+6. **KSA Engine Adapter**: Replace the placeholder with the real engine API when available
 
 ---
 

--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -1,6 +1,6 @@
 # PowerShell script to start all MCP servers
 param(
-    [ValidateSet('unity','godot')]
+    [ValidateSet('unity','godot','ksa')]
     [string]$Engine = 'unity'
 )
 
@@ -37,6 +37,7 @@ $gitRunning = Test-ServerPort -ServerName "Git MCP Server" -Port 8080
 $postgresRunning = Test-ServerPort -ServerName "Postgres MCP Server" -Port 8003
 $telemetryRunning = Test-ServerPort -ServerName "Telemetry Server" -Port 8090
 $proxyRunning = Test-ServerPort -ServerName "MCP Proxy Server" -Port 8004
+$ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port 8005
 
 # 1. Start Unity MCP Server if not already running
 if (-not $unityRunning) {
@@ -83,6 +84,15 @@ if (-not $proxyRunning) {
     Write-Host "Skipping MCP Proxy Server (already running)" -ForegroundColor Yellow
 }
 
+# 6. Start KSA Adapter
+if (-not $ksaRunning) {
+    Write-Host "Starting KSA Adapter..." -ForegroundColor Green
+    $ksaScript = Join-Path $scriptDir "run-ksa-server.ps1"
+    Start-Process PowerShell -ArgumentList "-File `"$ksaScript`"" -NoNewWindow
+} else {
+    Write-Host "Skipping KSA Adapter (already running)" -ForegroundColor Yellow
+}
+
 Write-Host "All MCP servers have been started!" -ForegroundColor Cyan
 Write-Host "Use the following servers in Cursor:" -ForegroundColor White
 Write-Host "- mcp-unity: ws://localhost:8001/McpUnity" -ForegroundColor White
@@ -90,3 +100,4 @@ Write-Host "- git: http://localhost:8080" -ForegroundColor White
 Write-Host "- postgres: http://localhost:8003" -ForegroundColor White
 Write-Host "- telemetry: http://localhost:8090" -ForegroundColor White
 Write-Host "- mcpProxy: http://localhost:8004" -ForegroundColor White
+Write-Host "- ksa-adapter: http://localhost:8005" -ForegroundColor White

--- a/run-ksa-server.ps1
+++ b/run-ksa-server.ps1
@@ -1,0 +1,43 @@
+param(
+    [int]$Port = 8005,
+    [string]$ServerPath
+)
+
+function Test-ValidPort {
+    param([int]$Port)
+    return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
+}
+
+$scriptDir = $PSScriptRoot
+if (-not $scriptDir) {
+    $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (-not $ServerPath) {
+    $ServerPath = Join-Path $scriptDir 'servers/ksa'
+}
+
+if (-not (Test-Path $ServerPath)) {
+    Write-Error "KSA adapter path not found: $ServerPath"
+    exit 1
+}
+
+try {
+    $nodeVersion = node --version
+    Write-Host "Using Node.js $nodeVersion"
+} catch {
+    Write-Error 'Node.js is required to run the KSA adapter.'
+    exit 1
+}
+
+Push-Location $ServerPath
+try {
+    $env:PORT = $Port
+    $process = Start-Process node -ArgumentList 'index.cjs' -NoNewWindow -PassThru
+    Write-Host "KSA adapter started on port $Port (PID: $($process.Id))" -ForegroundColor Green
+} finally {
+    Pop-Location
+}

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,0 +1,21 @@
+const http = require('http');
+const port = process.env.PORT || 8005;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body || '{}');
+    });
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('KSA MCP server placeholder');
+});
+
+server.listen(port, () => {
+  console.log(`KSA MCP server listening on port ${port}`);
+});
+server.on('error', err => console.error(err));

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -45,9 +45,11 @@ function post(port, pathName, data) {
   const gitPort = 8081;
   const pgPort = 8004;
   const telemetryPort = 8091;
+  const ksaPort = 8006;
   const git = startServer('servers/git/index.cjs', gitPort);
   const pg = startServer('servers/postgres/index.cjs', pgPort);
   const telemetry = startServer('servers/telemetry/index.cjs', telemetryPort);
+  const ksa = startServer('servers/ksa/index.cjs', ksaPort);
   const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
   async function waitForServer(port, timeout = 5000) {
@@ -70,6 +72,7 @@ function post(port, pathName, data) {
     waitForServer(gitPort),
     waitForServer(pgPort),
     waitForServer(telemetryPort),
+    waitForServer(ksaPort),
   ]);
   try {
     const gitResponse = await request(gitPort);
@@ -78,6 +81,11 @@ function post(port, pathName, data) {
     assert.strictEqual(pgResponse, 'Postgres MCP server placeholder');
     const telemetryResponse = await request(telemetryPort);
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
+    const ksaResponse = await request(ksaPort);
+    assert.strictEqual(ksaResponse, 'KSA MCP server placeholder');
+    const echo = await post(ksaPort, '/', { echo: 'test' });
+    assert.strictEqual(echo.statusCode, 200);
+    assert.strictEqual(echo.body, JSON.stringify({ echo: 'test' }));
     const postResult = await post(telemetryPort, '/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
 
@@ -92,10 +100,12 @@ function post(port, pathName, data) {
     git.kill();
     pg.kill();
     telemetry.kill();
+    ksa.kill();
   } catch (err) {
     git.kill();
     pg.kill();
     telemetry.kill();
+    ksa.kill();
     console.error(err);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- add `servers/ksa` with a placeholder Node server
- add `run-ksa-server.ps1` script
- start KSA adapter from `run-all-mcp-servers.ps1`
- document KSA adapter usage and future integration steps
- test coverage for KSA adapter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871cc874f348326b5d29b2210e52f5b