### PR TITLE
Add telemetry analytics metrics and tests

### DIFF
--- a/Documentation/Technical/Telemetry_Reports.md
+++ b/Documentation/Technical/Telemetry_Reports.md
@@ -1,0 +1,19 @@
+# Telemetry Reports
+
+The telemetry server records gameplay events in `servers/telemetry/logs/events.log`. The analytics
+module aggregates these events to provide high level metrics useful for debugging and balancing the game.
+
+## Metrics
+- **totalEvents** – number of events processed.
+- **eventCounts** – count of each event type.
+- **latestGeneration** – highest `generation` value seen in `generation_advanced` events.
+
+Developers can parse a log file directly:
+
+```javascript
+const analytics = require('../../servers/telemetry/analytics.cjs');
+const metrics = analytics.parseLogFile('servers/telemetry/logs/events.log');
+console.log(metrics);
+```
+
+These metrics are updated live whenever the telemetry server receives an event.

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -264,6 +264,7 @@ Log files are available in the following locations:
 - Server-Git: Terminal output only
 - Server-Postgres: `servers/postgres/logs`
 - Telemetry Server: `servers/telemetry/logs`
+- Telemetry reports: `Documentation/Technical/Telemetry_Reports.md`
 - MCPProxy: Terminal output only
 
 ## Future Enhancements

--- a/servers/telemetry/analytics.cjs
+++ b/servers/telemetry/analytics.cjs
@@ -1,6 +1,46 @@
-// Placeholder for future analytics functions
+const fs = require('fs');
+
+const metrics = {
+  totalEvents: 0,
+  eventCounts: {},
+  latestGeneration: null,
+};
+
+function updateMetrics(event) {
+  if (!event || typeof event !== 'object') return;
+  if (typeof event.type !== 'string') return;
+  metrics.totalEvents += 1;
+  metrics.eventCounts[event.type] = (metrics.eventCounts[event.type] || 0) + 1;
+  if (event.type === 'generation_advanced' && typeof event.generation === 'number') {
+    metrics.latestGeneration = event.generation;
+  }
+}
+
+function computeMetrics(event) {
+  updateMetrics(event);
+}
+
+function parseLogFile(filePath) {
+  if (!fs.existsSync(filePath)) return metrics;
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const lines = contents.split(/\r?\n/).filter(Boolean);
+  for (const line of lines) {
+    try {
+      const evt = JSON.parse(line);
+      updateMetrics(evt);
+    } catch {
+      // ignore invalid json
+    }
+  }
+  return metrics;
+}
+
+function getMetrics() {
+  return metrics;
+}
+
 module.exports = {
-  computeMetrics() {
-    // TODO: implement analytics processing of telemetry logs
-  },
+  computeMetrics,
+  parseLogFile,
+  getMetrics,
 };

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -3,6 +3,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const assert = require('assert');
+const analytics = require('../servers/telemetry/analytics.cjs');
 
 function startServer(relativePath, port) {
   const fullPath = path.join(__dirname, '..', relativePath);
@@ -88,6 +89,12 @@ function post(port, pathName, data) {
     const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
     const logContents = fs.readFileSync(logPath, 'utf8');
     assert.ok(logContents.includes(JSON.stringify(genEvent)));
+
+    const metrics = analytics.parseLogFile(logPath);
+    assert.strictEqual(metrics.totalEvents, 2);
+    assert.strictEqual(metrics.eventCounts.test, 1);
+    assert.strictEqual(metrics.eventCounts.generation_advanced, 1);
+    assert.strictEqual(metrics.latestGeneration, 1);
     console.log('Tests passed');
     git.kill();
     pg.kill();


### PR DESCRIPTION
## Summary
- implement analytics metrics in `servers/telemetry/analytics.cjs`
- test telemetry metrics reporting via log parsing
- document available telemetry reports
- link documentation in MCP integration guide

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871cc85ed68832692347d3eeeaf1d6e