### PR TITLE
Add Godot flight scene with MCP UI

### DIFF
--- a/Godot/Scenes/Flight.tscn
+++ b/Godot/Scenes/Flight.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource path="res://Scenes/Ship.tscn" type="PackedScene" id="1"]
+[ext_resource path="res://Scenes/UI/Hud.tscn" type="PackedScene" id="2"]
+
+[node name="Flight" type="Node3D" index="0"]
+
+[node name="Ship" parent="." instance=ExtResource("1")]
+
+[node name="Camera" type="Camera3D" parent="Ship"]
+translation = Vector3(0,3,-10)
+rotation_degrees = Vector3(10,0,0)
+current = true
+
+[node name="UI" parent="." instance=ExtResource("2")]

--- a/Godot/Scenes/Ship.tscn
+++ b/Godot/Scenes/Ship.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3]
+
+[node name="Ship" type="CharacterBody3D" index="0"]
+script = ExtResource("1")
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("2")
+
+[sub_resource type="BoxMesh" id="2"]
+size = Vector3(2,0.5,4)
+
+[ext_resource path="res://Scripts/SpaceshipMovement.cs" type="Script" id="1"]

--- a/Godot/Scenes/UI/Hud.tscn
+++ b/Godot/Scenes/UI/Hud.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://Scripts/McpClient.cs" type="Script" id="1"]
+
+[node name="HUD" type="Control" index="0"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -16.0
+margin_bottom = -16.0
+
+[node name="DockButton" type="Button" parent="VBox"]
+text = "Dock"
+
+[node name="UpgradeButton" type="Button" parent="VBox"]
+text = "Upgrade"
+
+[node name="RelaunchButton" type="Button" parent="VBox"]
+text = "Relaunch"

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -1,0 +1,37 @@
+using Godot;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public partial class McpClient : Control
+{
+    private const string Endpoint = "http://localhost:8001/mcp";
+
+    public override void _Ready()
+    {
+        GetNode<Button>("VBox/DockButton").Pressed += () => _ = SendCommand("Dock Ship");
+        GetNode<Button>("VBox/UpgradeButton").Pressed += () => _ = SendCommand("Ship/Upgrade");
+        GetNode<Button>("VBox/RelaunchButton").Pressed += () => _ = SendCommand("Ship/Relaunch");
+    }
+
+    private async Task SendCommand(string menuPath)
+    {
+        var payload = new
+        {
+            method = "execute_menu_item",
+            params = new { menuPath },
+            id = System.Guid.NewGuid().ToString()
+        };
+        var json = JsonSerializer.Serialize(payload);
+        var req = new HttpRequest();
+        AddChild(req);
+        var err = req.Request(Endpoint, new string[] { "Content-Type: application/json" }, HttpClient.Method.Post, json);
+        if (err != Error.Ok)
+        {
+            GD.PrintErr($"Request failed: {err}");
+            req.QueueFree();
+            return;
+        }
+        await ToSignal(req, HttpRequest.SignalName.RequestCompleted);
+        req.QueueFree();
+    }
+}

--- a/Godot/Scripts/SpaceshipMovement.cs
+++ b/Godot/Scripts/SpaceshipMovement.cs
@@ -1,0 +1,29 @@
+using Godot;
+using System.Threading.Tasks;
+
+public partial class SpaceshipMovement : CharacterBody3D
+{
+    [Export] public float ThrustForce = 10f;
+    [Export] public float MaxSpeed = 20f;
+    [Export] public float RotationSpeed = 90f;
+    [Export] public float BrakingForce = 5f;
+
+    public override void _PhysicsProcess(double delta)
+    {
+        var vel = Velocity;
+        float dt = (float)delta;
+
+        if (Input.IsActionPressed("move_forward"))
+            vel += -Transform.Basis.Z * ThrustForce * dt;
+        if (Input.IsActionPressed("move_backward"))
+            vel += Transform.Basis.Z * BrakingForce * dt;
+        if (Input.IsActionPressed("turn_left"))
+            RotateY(Mathf.DegToRad(-RotationSpeed * dt));
+        if (Input.IsActionPressed("turn_right"))
+            RotateY(Mathf.DegToRad(RotationSpeed * dt));
+
+        vel = vel.LimitLength(MaxSpeed);
+        Velocity = vel;
+        MoveAndSlide();
+    }
+}

--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -2,6 +2,13 @@
 
 [application]
 config/name="TBDSpaceRPG"
+run/main_scene="res://Scenes/Flight.tscn"
 
 [dotnet]
 project="TBDSpaceRPG.csproj"
+
+[input]
+move_forward={"deadzone":0.5,"events":[{"type":"key","scancode":87}]}
+move_backward={"deadzone":0.5,"events":[{"type":"key","scancode":83}]}
+turn_left={"deadzone":0.5,"events":[{"type":"key","scancode":65}]}
+turn_right={"deadzone":0.5,"events":[{"type":"key","scancode":68}]}


### PR DESCRIPTION
## Summary
- add SpaceshipMovement C# script for Godot
- create flight scene with ship and camera
- implement HUD with buttons sending MCP `execute_menu_item` commands
- configure input map and set main scene

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871cc85424c8326885eaee41251c526