### PR TITLE
Update docs for Godot workflow

### DIFF
--- a/Documentation/Technical/Godot_Migration_Steps.md
+++ b/Documentation/Technical/Godot_Migration_Steps.md
@@ -1,0 +1,12 @@
+# Migrating from Unity to Godot
+
+These steps outline how to move existing assets and workflows to the Godot pipeline.
+
+1. Export Unity prefabs or Blender models to the glTF format using a compatible exporter.
+2. Place all `.gltf` files in the `Assets_glTF/` directory at the project root.
+3. Open the project located in the `Godot/` folder. Godot will automatically import the glTF files and create scenes.
+4. Start the MCP servers configured for Godot:
+   ```powershell
+   ./run-all-mcp-servers.ps1 -Engine godot
+   ```
+5. Replace Unity-specific scripts with Godot equivalents and validate that gameplay features behave the same.

--- a/Documentation/Technical/README.md
+++ b/Documentation/Technical/README.md
@@ -16,4 +16,6 @@ This directory contains technical implementation documents for the TBD Space Gam
 - Gameplay_System/4. Technical Implementation.txt
 - Gameplay_System/4.12 UI_UX_Design.txt
 - Gameplay_System/6. Appendices.txt (technical sections)
-- Scripts/ (technical documentation) 
+
+- Scripts/ (technical documentation)
+- [Godot Migration Steps](Godot_Migration_Steps.md)

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -23,6 +23,7 @@ The TBD Space Game uses MCP (Model Context Protocol) to enable AI-assisted devel
 - **MCP Unity Fallback**: Backup server running on port 8002
 - **Server-Git**: Version control operations via MCP running on port 8080
 - **Server-Postgres**: Database operations via MCP running on port 8003
+- **Telemetry Server**: Collects runtime events on port 8090
 - **MCPProxy**: Routes requests to appropriate MCP servers running on port 8004
 
 These servers enable AI tools to interact with the Unity project, perform version control operations, manage database records, and more.
@@ -64,6 +65,14 @@ Manages database operations through MCP.
 # Start the PostgreSQL server
 ./run-postgres-server.ps1
 ```
+### Telemetry Server
+
+Collects runtime analytics and sends them to the telemetry dashboard.
+```powershell
+# Start the telemetry server
+./run-telemetry-server.ps1
+```
+
 
 ### MCPProxy
 
@@ -306,22 +315,18 @@ This script handles:
 - Path validation
 - Environment variable configuration
 - Server process management
-
-### Manual Server Start (If Needed)
-
-If you need to start the server manually, use semicolons for command chaining:
-
+### Safe MCP Server Restart
+Use `safe-mcp-restart.ps1` to restart the server without terminating unrelated Node processes:
 ```powershell
-cd "TBD SpaceGame\TBD SpaceGame\Library\PackageCache\com.gamelovers.mcp-unity@3acfb232f564\Server"; 
-$env:UNITY_PORT="8001"; 
-node build/index.js
+./safe-mcp-restart.ps1
 ```
 
-❌ DO NOT use the `&&` operator in PowerShell as it causes syntax errors:
+### Restart After Unity Update
+If Unity updates its packages, run `restart-mcp-after-unity-update.ps1` to reconnect:
 ```powershell
-# This will NOT work
-cd "path\to\server" && $env:UNITY_PORT="8001" && node build/index.js
+./restart-mcp-after-unity-update.ps1
 ```
+
 
 ## PowerShell Best Practices
 
@@ -440,6 +445,15 @@ This workflow verifies that menu items are found, commands are executed, and the
 - [MCP Unity Package Documentation](https://github.com/gamelovers/mcp-unity)
 - [Unity Editor Scripting Manual](https://docs.unity3d.com/Manual/ExtendingTheEditor.html) 
 ## Godot Integration
+
+### Exporting glTF Assets
+Use a glTF exporter (such as Unity's glTFast or Blender's exporter) to convert prefabs and models. Export them into `Assets_glTF/` so both Unity and Godot consume the same files.
+
+### Starting Servers for Godot
+Run all MCP servers configured for Godot with:
+```powershell
+./run-all-mcp-servers.ps1 -Engine godot
+```
 
 To import exported assets into Godot:
 1. Copy or move the contents of `Assets_glTF/` into the `Godot` project folder.

--- a/Unity-MCP-Integration-Manual.md
+++ b/Unity-MCP-Integration-Manual.md
@@ -144,18 +144,6 @@ EditorApplication.ExecuteMenuItem("MCP/Ship/V2/Create Test Ship");
    .\test-menu.ps1 -MenuPath "MCP/Ship/V2/Log Current Upgrades"
    ```
 
-### Standard Unity Operations
-
-Always test standard Unity menu paths if custom paths aren't working:
-
-```powershell
-# Create empty GameObject
-.\test-menu.ps1 -MenuPath "GameObject/Create Empty"
-
-# Create 3D cube
-.\test-menu.ps1 -MenuPath "GameObject/3D Object/Cube"
-```
-
 ## CI/CD Integration
 
 The MCP integration can be incorporated into your CI/CD pipeline to automate testing and validation of Unity menu items.
@@ -380,14 +368,27 @@ public class ShipCustomizationWindow : EditorWindow
 5. **Test in Edit mode**: Ensure all functionality works in Edit mode, not just Play mode
 6. **Maintain undo support**: Use Undo.RecordObject for changes to persist properly
 
-## Appendix: Common Unity Menu Paths
+## Server Utility Scripts
 
-These standard Unity menu paths should work reliably:
+Use `safe-mcp-restart.ps1` to safely restart the MCP server without killing unrelated Node processes:
+```powershell
+./safe-mcp-restart.ps1
+```
+If Unity updates its packages, run `restart-mcp-after-unity-update.ps1`:
+```powershell
+./restart-mcp-after-unity-update.ps1
+```
 
-- `GameObject/Create Empty`
-- `GameObject/3D Object/Cube`
-- `GameObject/3D Object/Sphere`
-- `GameObject/Light/Directional Light`
-- `GameObject/UI/Button`
-- `Edit/Duplicate`
-- `Edit/Delete` 
+
+## Godot Workflow
+
+### Exporting glTF Assets
+Use the glTFast plugin or Blender\x27s exporter to convert Unity prefabs or Blender models into `.gltf` files. Place the exports in `Assets_glTF/`.
+
+### Launching Servers for Godot
+Start all MCP services with Godot-specific settings:
+```powershell
+./run-all-mcp-servers.ps1 -Engine godot
+```
+
+The Godot project under `Godot/` will automatically import these assets and generate reusable scenes.


### PR DESCRIPTION
## Summary
- document telemetry server and safe restart commands
- add Godot setup and glTF export details
- remove outdated Unity instructions
- add migration steps to Technical docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871cc8c177083268f532c3c241ddfb0