### PR TITLE
Add ShipCustomization tests and MCP command test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,16 @@ jobs:
       - run: npm run lint
       - run: npm test
 
+  dotnet-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal
+      - run: dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal
+
   unity-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 servers/telemetry/logs/
+**/bin/
+**/obj/

--- a/csharp/OrbitalMechanics/OrbitalMechanics.csproj
+++ b/csharp/OrbitalMechanics/OrbitalMechanics.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/*.cs" />
+    <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Scripts/ShipCustomization/SpaceshipMovement.cs" />
     <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/*.cs" />
     <Compile Include="../UnityStubs/UnityEngine.cs" />
   </ItemGroup>

--- a/csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj
+++ b/csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ShipCustomization/ShipCustomization.csproj" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/csharp/ShipCustomization.Tests/ShipCustomizationManagerTests.cs
+++ b/csharp/ShipCustomization.Tests/ShipCustomizationManagerTests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class ShipCustomizationManagerTests
+{
+    [Test]
+    public void UpgradeThrust_IncreasesLevelAndAppliesToMovement()
+    {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { movement = movement };
+        manager.UpgradeThrust();
+        Assert.AreEqual(2, manager.thrustLevel);
+        Assert.AreEqual(20f, movement.thrustForce);
+    }
+
+    [Test]
+    public void ResetUpgrades_SetsLevelsToOne()
+    {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { movement = movement };
+        manager.UpgradeSpeed();
+        manager.ResetUpgrades();
+        Assert.AreEqual(1, manager.speedLevel);
+        Assert.AreEqual(20f, movement.maxSpeed);
+    }
+}

--- a/csharp/ShipCustomization.Tests/SpaceshipMovementTests.cs
+++ b/csharp/ShipCustomization.Tests/SpaceshipMovementTests.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class SpaceshipMovementTests
+{
+    [Test]
+    public void FixedUpdate_ForwardKeyAppliesThrust()
+    {
+        var rb = new Rigidbody();
+        var movement = new SpaceshipMovement();
+        typeof(SpaceshipMovement).GetField("_rb", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(movement, rb);
+        Input.SetKey(KeyCode.W, true);
+        movement.thrustForce = 5f;
+        movement.maxSpeed = 100f;
+        typeof(SpaceshipMovement).GetMethod("FixedUpdate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.Invoke(movement, null);
+        Assert.AreEqual(0f, rb.velocity.x);
+        Assert.AreEqual(0f, rb.velocity.y);
+        Assert.AreEqual(5f, rb.velocity.z);
+        Input.SetKey(KeyCode.W, false);
+    }
+
+    [Test]
+    public void FixedUpdate_ClampsVelocity()
+    {
+        var rb = new Rigidbody();
+        var movement = new SpaceshipMovement();
+        typeof(SpaceshipMovement).GetField("_rb", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(movement, rb);
+        Input.SetKey(KeyCode.W, true);
+        movement.thrustForce = 50f;
+        movement.maxSpeed = 10f;
+        typeof(SpaceshipMovement).GetMethod("FixedUpdate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.Invoke(movement, null);
+        Assert.AreEqual(10f, rb.velocity.magnitude);
+        Input.SetKey(KeyCode.W, false);
+    }
+}

--- a/csharp/ShipCustomization/ShipCustomization.csproj
+++ b/csharp/ShipCustomization/ShipCustomization.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../TBD SpaceGame/TBD SpaceGame/Assets/Scripts/ShipCustomization/*.cs" />
+    <Compile Include="../UnityStubs/UnityEngine.cs" />
+  </ItemGroup>
+</Project>

--- a/csharp/UnityStubs/UnityEngine.cs
+++ b/csharp/UnityStubs/UnityEngine.cs
@@ -7,6 +7,8 @@ namespace UnityEngine
         public float x, y, z;
         public Vector3(float x, float y, float z) { this.x = x; this.y = y; this.z = z; }
         public static Vector3 zero => new Vector3(0, 0, 0);
+        public static Vector3 up => new Vector3(0, 1, 0);
+        public static Vector3 forward => new Vector3(0, 0, 1);
         public static float Distance(Vector3 a, Vector3 b)
         {
             float dx = a.x - b.x;
@@ -23,7 +25,14 @@ namespace UnityEngine
             }
         }
         public float magnitude => (float)Math.Sqrt(x*x + y*y + z*z);
+        public static Vector3 ClampMagnitude(Vector3 v, float max)
+        {
+            var mag = v.magnitude;
+            return mag > max ? v.normalized * max : v;
+        }
+        public static Vector3 operator -(Vector3 v) => new Vector3(-v.x, -v.y, -v.z);
         public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x-b.x, a.y-b.y, a.z-b.z);
+        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.x+b.x, a.y+b.y, a.z+b.z);
         public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x*d, v.y*d, v.z*d);
     }
 
@@ -32,6 +41,7 @@ namespace UnityEngine
         public GameObject gameObject = new GameObject();
         public string name { get => gameObject.name; set => gameObject.name = value; }
         public static void Destroy(object obj) {}
+        public T GetComponent<T>() where T : class => gameObject.GetComponent<T>();
     }
 
     public class SerializeField : Attribute {}
@@ -50,13 +60,51 @@ namespace UnityEngine
     public class Transform
     {
         public Vector3 position;
+        public Vector3 forward = Vector3.forward;
     }
 
     public class GameObject
     {
         public string name = string.Empty;
         public Transform transform = new Transform();
+        private readonly System.Collections.Generic.Dictionary<System.Type, object> _components = new System.Collections.Generic.Dictionary<System.Type, object>();
+        public T AddComponent<T>() where T : new()
+        {
+            var comp = new T();
+            _components[typeof(T)] = comp;
+            return comp;
+        }
+        public T GetComponent<T>() where T : class
+        {
+            _components.TryGetValue(typeof(T), out var obj);
+            return obj as T;
+        }
+    }
+
+    public static class Debug
+    {
+        public static void Log(string msg) { }
+        public static void LogError(string msg) { }
+    }
+
+    public enum KeyCode { W, A, S, D }
+
+    public static class Input
+    {
+        private static readonly System.Collections.Generic.HashSet<KeyCode> _pressed = new System.Collections.Generic.HashSet<KeyCode>();
+        public static bool GetKey(KeyCode code) => _pressed.Contains(code);
+        public static void SetKey(KeyCode code, bool value)
+        {
+            if (value) _pressed.Add(code); else _pressed.Remove(code);
+        }
+    }
+
+    public class Rigidbody
+    {
+        public Vector3 velocity;
+        public Vector3 torque;
+        public void AddForce(Vector3 force) { velocity += force; }
+        public void AddTorque(Vector3 t) { torque += t; }
     }
 
 }
-public class SpaceshipMovement : UnityEngine.MonoBehaviour {}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "node tests/server.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
+    "test": "node tests/server.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
     "lint": "eslint servers tests"
   },
   "devDependencies": {

--- a/tests/mcp-commands.test.cjs
+++ b/tests/mcp-commands.test.cjs
@@ -1,0 +1,34 @@
+const http = require('http');
+const assert = require('assert');
+
+function post(body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: 'localhost', port: 8001, path: '/mcp', method: 'POST', headers: {'Content-Type':'application/json'} }, res => {
+      res.resume();
+      res.on('end', resolve);
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+(async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', c => body += c);
+    req.on('end', () => { received.push(JSON.parse(body)); res.end('ok'); });
+  });
+  await new Promise(r => server.listen(8001, r));
+  try {
+    await post({ method: 'execute_menu_item', params: { menuPath: 'Test/Path' }, id: '1' });
+    await post({ method: 'notify_message', params: { message: 'hi', logType: 'Log' }, id: '2' });
+    assert.strictEqual(received.length, 2);
+    assert.strictEqual(received[0].method, 'execute_menu_item');
+    assert.strictEqual(received[1].method, 'notify_message');
+    console.log('MCP command tests passed');
+  } finally {
+    server.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- extend Unity stubs for basic physics and input
- create ShipCustomization library and NUnit tests
- add Node test for MCP command handling
- update Node test script and CI workflow
- ignore build artifacts

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity minimal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6871cc890da48326b3a8e140da073a95