### PR TITLE
Add editorconfig and dotnet format check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+
+# Sort System directives first
+dotnet_sort_system_directives_first = true
+# Separate groups of using directives
+dotnet_separate_import_directive_groups = true
+
+# Prefer braces
+csharp_prefer_braces = true:suggestion
+
+# Naming conventions
+# Private fields use _camelCase
+# Public members use PascalCase
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
       - uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: npm ci
+      - run: dotnet format --verify-no-changes csharp/OrbitalMechanics.sln
       - run: npm run lint
       - run: npm test
 

--- a/Output/Code_Style_Guide.txt
+++ b/Output/Code_Style_Guide.txt
@@ -1,6 +1,6 @@
 # TBD Space Game - Code Style Guide
-Version: 1.0
-Date: April 5, 2025
+Version: 1.1
+Date: May 1, 2025
 
 ## 1. Naming Conventions
 
@@ -322,5 +322,13 @@ public void TestFactionInfluence()
 }
 ```
 
+## 5. Automated Formatting
+The repository includes an `.editorconfig` file that defines consistent C#
+styling rules such as 4-space indentation and groupings of `using`
+directives.  Continuous integration runs `dotnet format --verify-no-changes`
+against the `OrbitalMechanics.sln` solution to ensure all committed code
+adheres to these settings.
+
 ## Version History
-- v1.0 (April 5, 2025): Initial guide creation 
+- v1.1 (May 1, 2025): Documented automated formatting rules
+- v1.0 (April 5, 2025): Initial guide creation

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/KeplerOrbit.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Plugins/SimpleKeplerOrbits/KeplerOrbit.cs
@@ -1,6 +1,8 @@
 using System;
-using UnityEngine;
+
 using OrbitalMechanics;
+
+using UnityEngine;
 
 namespace SimpleKeplerOrbits
 {

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/InterceptCalculator.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/InterceptCalculator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using UnityEngine;
 
 namespace OrbitalMechanics.Combat

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitData.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitData.cs
@@ -1,5 +1,6 @@
-using UnityEngine;
 using SimpleKeplerOrbits;
+
+using UnityEngine;
 
 namespace OrbitalMechanics
 {

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitManager.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using UnityEngine;
 
 namespace OrbitalMechanics

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitPlanner.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/OrbitPlanner.cs
@@ -1,5 +1,6 @@
-using UnityEngine;
 using SimpleKeplerOrbits;
+
+using UnityEngine;
 
 namespace OrbitalMechanics
 {

--- a/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/Vector3d.cs
+++ b/TBD SpaceGame/TBD SpaceGame/Assets/Scripts/OrbitalMechanics/Vector3d.cs
@@ -1,4 +1,5 @@
 using System;
+
 using UnityEngine;
 
 namespace OrbitalMechanics

--- a/csharp/OrbitalMechanics.Tests/OrbitTests.cs
+++ b/csharp/OrbitalMechanics.Tests/OrbitTests.cs
@@ -1,9 +1,13 @@
+using System.Reflection;
+
 using NUnit.Framework;
+
 using OrbitalMechanics;
 using OrbitalMechanics.Combat;
+
 using SimpleKeplerOrbits;
+
 using UnityEngine;
-using System.Reflection;
 
 namespace OrbitalMechanics.Tests
 {

--- a/csharp/UnityStubs/UnityEngine.cs
+++ b/csharp/UnityStubs/UnityEngine.cs
@@ -12,30 +12,31 @@ namespace UnityEngine
             float dx = a.x - b.x;
             float dy = a.y - b.y;
             float dz = a.z - b.z;
-            return (float)Math.Sqrt(dx*dx + dy*dy + dz*dz);
+            return (float)Math.Sqrt(dx * dx + dy * dy + dz * dz);
         }
         public Vector3 normalized
         {
             get
             {
-                float mag = (float)Math.Sqrt(x*x + y*y + z*z);
-                return mag > 1e-5 ? new Vector3(x/mag, y/mag, z/mag) : zero;
+                float mag = (float)Math.Sqrt(x * x + y * y + z * z);
+                return mag > 1e-5 ? new Vector3(x / mag, y / mag, z / mag) : zero;
             }
         }
-        public float magnitude => (float)Math.Sqrt(x*x + y*y + z*z);
-        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x-b.x, a.y-b.y, a.z-b.z);
-        public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x*d, v.y*d, v.z*d);
+        public float magnitude => (float)Math.Sqrt(x * x + y * y + z * z);
+        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
+        public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x * d, v.y * d, v.z * d);
     }
 
-    public class MonoBehaviour {
+    public class MonoBehaviour
+    {
         public Transform transform = new Transform();
         public GameObject gameObject = new GameObject();
         public string name { get => gameObject.name; set => gameObject.name = value; }
-        public static void Destroy(object obj) {}
+        public static void Destroy(object obj) { }
     }
 
-    public class SerializeField : Attribute {}
-    public class RequireComponent : Attribute { public RequireComponent(Type t) {} }
+    public class SerializeField : Attribute { }
+    public class RequireComponent : Attribute { public RequireComponent(Type t) { } }
 
     public static class Mathf
     {
@@ -59,4 +60,4 @@ namespace UnityEngine
     }
 
 }
-public class SpaceshipMovement : UnityEngine.MonoBehaviour {}
+public class SpaceshipMovement : UnityEngine.MonoBehaviour { }


### PR DESCRIPTION
## Summary
- add repository-level `.editorconfig` with basic C# rules
- enforce formatting in CI using `dotnet format --verify-no-changes`
- describe automated formatting in the code style guide
- apply `dotnet format` to existing C# files so the formatting check passes

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/OrbitalMechanics.sln`
- `dotnet format --verify-no-changes csharp/OrbitalMechanics.sln`


------
https://chatgpt.com/codex/tasks/task_e_6871cc8c79748326ac76434fb9f4dee7