### PR TITLE
Fix UnityEngine stubs for tests

### DIFF
--- a/csharp/UnityStubs/UnityEngine.cs
+++ b/csharp/UnityStubs/UnityEngine.cs
@@ -26,7 +26,14 @@ namespace UnityEngine
         }
         public float magnitude => (float)Math.Sqrt(x * x + y * y + z * z);
         public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
+        public static Vector3 operator -(Vector3 v) => new Vector3(-v.x, -v.y, -v.z);
+        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
         public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x * d, v.y * d, v.z * d);
+        public static Vector3 ClampMagnitude(Vector3 v, float max)
+        {
+            float mag = v.magnitude;
+            return mag > max ? v.normalized * max : v;
+        }
 
     }
 
@@ -36,6 +43,8 @@ namespace UnityEngine
         public GameObject gameObject = new GameObject();
         public string name { get => gameObject.name; set => gameObject.name = value; }
         public static void Destroy(object obj) { }
+        public T GetComponent<T>() where T : class => gameObject.GetComponent<T>();
+        public T AddComponent<T>() where T : new() => gameObject.AddComponent<T>();
 
     }
 
@@ -103,5 +112,7 @@ namespace UnityEngine
     }
 
 }
+#if false
 public class SpaceshipMovement : UnityEngine.MonoBehaviour { }
+#endif
 


### PR DESCRIPTION
## Summary
- add missing operators and ClampMagnitude to Vector3
- expose `GetComponent` and `AddComponent` in `MonoBehaviour`
- wrap unused `SpaceshipMovement` stub in `#if false`
- ensure `ShipCustomization.Tests` and `OrbitalMechanics.Tests` pass

## Testing
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj -v minimal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6871db7816b88326ba4758fb30aefeb5