### PR TITLE
Run npm ci before lint and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
       - run: dotnet format --verify-no-changes csharp/OrbitalMechanics.sln
+      - run: npm ci
       - run: npm run lint
+      - run: npm ci
       - run: npm test
 
   dotnet-tests:

--- a/Documentation/Development/README.md
+++ b/Documentation/Development/README.md
@@ -18,3 +18,4 @@ This directory contains development workflow and process documentation for the T
 - MCP integration documentation
 - Terminal and environment setup guides
 - Use `npm ci` to install Node.js dependencies
+- Run `npm ci` again before executing `npm run lint` or `npm test`

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -225,6 +225,8 @@ public class McpServerAutoRestarter
 
 All automated tests use PowerShell scripts. Ensure that the `pwsh` command is available before running tests.
 
+Run `npm ci` to install Node.js dependencies before executing the test script.
+
 ```pwsh
 pwsh -File tests/test-servers.ps1
 ```

--- a/csharp/UnityStubs/UnityEngine.cs
+++ b/csharp/UnityStubs/UnityEngine.cs
@@ -25,8 +25,15 @@ namespace UnityEngine
             }
         }
         public float magnitude => (float)Math.Sqrt(x * x + y * y + z * z);
+        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
         public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
+        public static Vector3 operator -(Vector3 v) => new Vector3(-v.x, -v.y, -v.z);
         public static Vector3 operator *(Vector3 v, float d) => new Vector3(v.x * d, v.y * d, v.z * d);
+        public static Vector3 operator *(float d, Vector3 v) => v * d;
+        public static Vector3 ClampMagnitude(Vector3 vector, float maxLength)
+        {
+            return vector.magnitude > maxLength ? vector.normalized * maxLength : vector;
+        }
 
     }
 
@@ -36,6 +43,8 @@ namespace UnityEngine
         public GameObject gameObject = new GameObject();
         public string name { get => gameObject.name; set => gameObject.name = value; }
         public static void Destroy(object obj) { }
+        public T AddComponent<T>() where T : new() => gameObject.AddComponent<T>();
+        public T GetComponent<T>() where T : class => gameObject.GetComponent<T>();
 
     }
 
@@ -103,5 +112,4 @@ namespace UnityEngine
     }
 
 }
-public class SpaceshipMovement : UnityEngine.MonoBehaviour { }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prelint": "npm ci",
+    "pretest": "npm ci",
     "test": "node tests/server.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
     "lint": "eslint servers tests"
   },


### PR DESCRIPTION
## Summary
- run `npm ci` before lint/test in CI workflow
- ensure `npm ci` runs automatically before `npm run lint` and `npm test`
- document the need for `npm ci` before linting or testing
- fix Unity stub to let dotnet tests compile

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity minimal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6871db79201883269f97fbabf270de5f