### PR TITLE
Add shared engine config and update PowerShell scripts

### DIFF
--- a/engine-config.json
+++ b/engine-config.json
@@ -1,0 +1,30 @@
+{
+  "unity": {
+    "port": 8001,
+    "directory": "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server"
+  },
+  "godot": {
+    "port": 8001,
+    "directory": "servers/godot"
+  },
+  "git": {
+    "port": 8080,
+    "directory": "servers/git"
+  },
+  "postgres": {
+    "port": 8003,
+    "directory": "servers/postgres"
+  },
+  "telemetry": {
+    "port": 8090,
+    "directory": "servers/telemetry"
+  },
+  "mcpproxy": {
+    "port": 8004,
+    "directory": "servers/mcpProxy"
+  },
+  "ksa": {
+    "port": 8005,
+    "directory": "servers/ksa"
+  }
+}

--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -1,7 +1,8 @@
 # PowerShell script to start all MCP servers
 param(
     [ValidateSet('unity','godot','ksa')]
-    [string]$Engine = 'unity'
+    [string]$Engine = 'unity',
+    [string]$ConfigFile = 'engine-config.json'
 )
 
 Write-Host "Starting All MCP Servers..." -ForegroundColor Cyan
@@ -13,6 +14,34 @@ if (-not $scriptDir) {
 }
 if (-not $scriptDir) {
     $scriptDir = $PWD.Path
+}
+
+# Load engine configuration
+$engineCfg = $null
+if (Test-Path $ConfigFile) {
+    try {
+        $engineCfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        Write-Host "Using configuration from $ConfigFile" -ForegroundColor Green
+    } catch {
+        Write-Warning "Failed to load engine configuration from $ConfigFile: $_"
+    }
+}
+
+# Determine ports
+$unityPort = 8001
+$gitPort = 8080
+$postgresPort = 8003
+$telemetryPort = 8090
+$proxyPort = 8004
+$ksaPort = 8005
+
+if ($engineCfg) {
+    if ($engineCfg.unity.port) { $unityPort = [int]$engineCfg.unity.port }
+    if ($engineCfg.git.port) { $gitPort = [int]$engineCfg.git.port }
+    if ($engineCfg.postgres.port) { $postgresPort = [int]$engineCfg.postgres.port }
+    if ($engineCfg.telemetry.port) { $telemetryPort = [int]$engineCfg.telemetry.port }
+    if ($engineCfg.mcpproxy.port) { $proxyPort = [int]$engineCfg.mcpproxy.port }
+    if ($engineCfg.ksa.port) { $ksaPort = [int]$engineCfg.ksa.port }
 }
 
 # Function to check server ports
@@ -43,18 +72,18 @@ function Test-ServerPort {
 }
 
 # First, check if any server is already running
-$unityRunning = Test-ServerPort -ServerName "Unity MCP Server" -Port 8001
-$gitRunning = Test-ServerPort -ServerName "Git MCP Server" -Port 8080
-$postgresRunning = Test-ServerPort -ServerName "Postgres MCP Server" -Port 8003
-$telemetryRunning = Test-ServerPort -ServerName "Telemetry Server" -Port 8090
-$proxyRunning = Test-ServerPort -ServerName "MCP Proxy Server" -Port 8004
-$ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port 8005
+$unityRunning = Test-ServerPort -ServerName "Unity MCP Server" -Port $unityPort
+$gitRunning = Test-ServerPort -ServerName "Git MCP Server" -Port $gitPort
+$postgresRunning = Test-ServerPort -ServerName "Postgres MCP Server" -Port $postgresPort
+$telemetryRunning = Test-ServerPort -ServerName "Telemetry Server" -Port $telemetryPort
+$proxyRunning = Test-ServerPort -ServerName "MCP Proxy Server" -Port $proxyPort
+$ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port $ksaPort
 
 # 1. Start Unity MCP Server if not already running
 if (-not $unityRunning) {
     Write-Host "Starting Unity MCP Server..." -ForegroundColor Green
     $unityScript = Join-Path $scriptDir "run-mcp-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Unity MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -63,7 +92,7 @@ if (-not $unityRunning) {
 if (-not $gitRunning) {
     Write-Host "Starting Git MCP Server..." -ForegroundColor Green
     $gitScript = Join-Path $scriptDir "run-git-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$gitScript`"" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$gitScript`" -Port $gitPort -ConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Git MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -72,7 +101,7 @@ if (-not $gitRunning) {
 if (-not $postgresRunning) {
     Write-Host "Starting Postgres MCP Server..." -ForegroundColor Green
     $postgresScript = Join-Path $scriptDir "run-postgres-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$postgresScript`"" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$postgresScript`" -Port $postgresPort -ConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Postgres MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -81,7 +110,7 @@ if (-not $postgresRunning) {
 if (-not $telemetryRunning) {
     Write-Host "Starting Telemetry Server..." -ForegroundColor Green
     $telemetryScript = Join-Path $scriptDir "run-telemetry-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$telemetryScript`"" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$telemetryScript`" -Port $telemetryPort -ConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Telemetry Server (already running)" -ForegroundColor Yellow
 }
@@ -90,7 +119,7 @@ if (-not $telemetryRunning) {
 if (-not $proxyRunning) {
     Write-Host "Starting MCP Proxy Server..." -ForegroundColor Green
     $proxyScript = Join-Path $scriptDir "run-mcpproxy-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$proxyScript`"" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$proxyScript`" -Port $proxyPort -ConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping MCP Proxy Server (already running)" -ForegroundColor Yellow
 }
@@ -99,16 +128,16 @@ if (-not $proxyRunning) {
 if (-not $ksaRunning) {
     Write-Host "Starting KSA Adapter..." -ForegroundColor Green
     $ksaScript = Join-Path $scriptDir "run-ksa-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$ksaScript`"" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$ksaScript`" -Port $ksaPort -ConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping KSA Adapter (already running)" -ForegroundColor Yellow
 }
 
 Write-Host "All MCP servers have been started!" -ForegroundColor Cyan
 Write-Host "Use the following servers in Cursor:" -ForegroundColor White
-Write-Host "- mcp-unity: ws://localhost:8001/McpUnity" -ForegroundColor White
-Write-Host "- git: http://localhost:8080" -ForegroundColor White
-Write-Host "- postgres: http://localhost:8003" -ForegroundColor White
-Write-Host "- telemetry: http://localhost:8090" -ForegroundColor White
-Write-Host "- mcpProxy: http://localhost:8004" -ForegroundColor White
-Write-Host "- ksa-adapter: http://localhost:8005" -ForegroundColor White
+Write-Host "- mcp-unity: ws://localhost:$unityPort/McpUnity" -ForegroundColor White
+Write-Host "- git: http://localhost:$gitPort" -ForegroundColor White
+Write-Host "- postgres: http://localhost:$postgresPort" -ForegroundColor White
+Write-Host "- telemetry: http://localhost:$telemetryPort" -ForegroundColor White
+Write-Host "- mcpProxy: http://localhost:$proxyPort" -ForegroundColor White
+Write-Host "- ksa-adapter: http://localhost:$ksaPort" -ForegroundColor White

--- a/run-git-server.ps1
+++ b/run-git-server.ps1
@@ -1,6 +1,7 @@
 param(
     [int]$Port = 8080,
-    [string]$ServerPath
+    [string]$ServerPath,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 function Test-ValidPort {
@@ -16,6 +17,17 @@ if (-not (Test-ValidPort -Port $Port)) {
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.git) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and $cfg.git.port) { $Port = [int]$cfg.git.port }
+            if (-not $ServerPath -and $cfg.git.directory) { $ServerPath = Join-Path $scriptDir $cfg.git.directory }
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/git'

--- a/run-ksa-server.ps1
+++ b/run-ksa-server.ps1
@@ -1,6 +1,7 @@
 param(
     [int]$Port = 8005,
-    [string]$ServerPath
+    [string]$ServerPath,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 function Test-ValidPort {
@@ -15,6 +16,17 @@ if (-not (Test-ValidPort -Port $Port)) {
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.ksa) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and $cfg.ksa.port) { $Port = [int]$cfg.ksa.port }
+            if (-not $ServerPath -and $cfg.ksa.directory) { $ServerPath = Join-Path $scriptDir $cfg.ksa.directory }
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/ksa'

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -1,13 +1,14 @@
 # run-mcp-server.ps1
 # Purpose: Starts the MCP Unity server with proper environment configuration
-# Usage: .\run-mcp-server.ps1 [-Port <port_number>] [-Monitor] [-ConfigFile <path>]
+# Usage: .\run-mcp-server.ps1 [-Port <port_number>] [-Monitor] [-ConfigFile <path>] [-EngineConfigFile <path>]
 
 param (
     [int]$Port = 8001,
     [ValidateSet("unity","godot")]
     [string]$Engine = "unity",
     [switch]$Monitor,
-    [string]$ConfigFile = ".mcp-server-config.json"
+    [string]$ConfigFile = ".mcp-server-config.json",
+    [string]$EngineConfigFile = "engine-config.json"
 )
 
 # Validate the supplied port number
@@ -29,13 +30,14 @@ $config = @{
     "nodeEnv" = "production"
     "engine" = $Engine
 }
+$portFromConfig = $false
 
 if (Test-Path $ConfigFile) {
     try {
         $configData = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
         
         # Override defaults with config file values
-        if ($configData.port) { $config.port = $configData.port }
+        if ($configData.port) { $config.port = $configData.port; $portFromConfig = $true }
         if ($configData.serverPath) { $config.serverPath = $configData.serverPath }
         if ($configData.logFile) { $config.logFile = $configData.logFile }
         if ($configData.nodeEnv) { $config.nodeEnv = $configData.nodeEnv }
@@ -60,6 +62,24 @@ if ($PSBoundParameters.ContainsKey('Engine')) {
 $projectRoot = $PSScriptRoot
 $unityProjectPath = Join-Path $projectRoot "TBD SpaceGame"
 $godotServerPath = Join-Path $projectRoot "servers\godot"
+
+# Load engine-specific defaults from the engine config file
+if (Test-Path $EngineConfigFile) {
+    try {
+        $engineData = Get-Content -Path $EngineConfigFile -Raw | ConvertFrom-Json
+        $engineEntry = $engineData.$($config.engine)
+        if ($engineEntry) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and -not $portFromConfig -and $engineEntry.port) {
+                $config.port = [int]$engineEntry.port
+            }
+            if (-not $config.serverPath -and $engineEntry.directory) {
+                $config.serverPath = Join-Path $projectRoot $engineEntry.directory
+            }
+        }
+    } catch {
+        Write-Warning "Failed to load engine configuration from $EngineConfigFile: $_"
+    }
+}
 
 # Use config serverPath if provided, otherwise use default
 if (-not $config.serverPath) {

--- a/run-mcpproxy-server.ps1
+++ b/run-mcpproxy-server.ps1
@@ -1,6 +1,8 @@
 
 param(
-    [string]$ProxyPath
+    [int]$Port = 8004,
+    [string]$ProxyPath,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 # PowerShell script to start the MCP Proxy server
@@ -9,6 +11,17 @@ Write-Host "Starting MCP Proxy Server..."
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.mcpproxy) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and $cfg.mcpproxy.port) { $Port = [int]$cfg.mcpproxy.port }
+            if (-not $ProxyPath -and $cfg.mcpproxy.directory) { $ProxyPath = Join-Path $scriptDir $cfg.mcpproxy.directory }
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
 }
 if (-not $ProxyPath) {
     # Default to the "servers/mcpProxy" directory relative to this script
@@ -20,8 +33,8 @@ function Test-ValidPort {
     return $Port -ge 1 -and $Port -le 65535
 }
 
-if (-not (Test-ValidPort -Port 8004)) {
-    Write-Error "Invalid port: 8004. Must be between 1 and 65535."
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port: $Port. Must be between 1 and 65535."
     exit 1
 }
 
@@ -46,6 +59,6 @@ try {
 # Start the mcpProxy server as a background job
 Start-Process node -ArgumentList "dist/src/index.js" -NoNewWindow -PassThru
 
-Write-Host "MCP Proxy Server started on port 8004"
+Write-Host "MCP Proxy Server started on port $Port"
 Write-Host "Server will run in the background. To stop, close the Node.js process."
 

--- a/run-postgres-server.ps1
+++ b/run-postgres-server.ps1
@@ -1,6 +1,7 @@
 param(
     [int]$Port = 8003,
-    [string]$ServerPath
+    [string]$ServerPath,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 function Test-ValidPort {
@@ -16,6 +17,17 @@ if (-not (Test-ValidPort -Port $Port)) {
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.postgres) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and $cfg.postgres.port) { $Port = [int]$cfg.postgres.port }
+            if (-not $ServerPath -and $cfg.postgres.directory) { $ServerPath = Join-Path $scriptDir $cfg.postgres.directory }
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/postgres'

--- a/run-telemetry-server.ps1
+++ b/run-telemetry-server.ps1
@@ -1,6 +1,7 @@
 param(
     [int]$Port = 8090,
-    [string]$ServerPath
+    [string]$ServerPath,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 function Test-ValidPort {
@@ -15,6 +16,17 @@ if (-not (Test-ValidPort -Port $Port)) {
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) {
     $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.telemetry) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and $cfg.telemetry.port) { $Port = [int]$cfg.telemetry.port }
+            if (-not $ServerPath -and $cfg.telemetry.directory) { $ServerPath = Join-Path $scriptDir $cfg.telemetry.directory }
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/telemetry'


### PR DESCRIPTION
## Summary
- add `engine-config.json` for defining engine ports and directories
- update PowerShell server scripts to read from the new config
- pass port and config parameters through `run-all-mcp-servers.ps1`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873205f0a10832683728aebdfee4d5a