### PR TITLE
Make MCP endpoint configurable

### DIFF
--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -4,10 +4,19 @@ using System.Threading.Tasks;
 
 public partial class McpClient : Control
 {
-    private const string Endpoint = "http://localhost:8001/mcp";
+    [Export] public string Endpoint = "http://localhost:8001/mcp";
 
     public override void _Ready()
     {
+        if (ProjectSettings.HasSetting("application/mcp_endpoint"))
+        {
+            var cfg = ProjectSettings.GetSetting("application/mcp_endpoint");
+            if (cfg is StringName sn)
+                Endpoint = sn.ToString();
+            else if (cfg is string str)
+                Endpoint = str;
+        }
+
         GetNode<Button>("VBox/DockButton").Pressed += () => _ = SendCommand("Dock Ship");
         GetNode<Button>("VBox/UpgradeButton").Pressed += () => _ = SendCommand("Ship/Upgrade");
         GetNode<Button>("VBox/RelaunchButton").Pressed += () => _ = SendCommand("Ship/Relaunch");

--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -3,6 +3,7 @@
 [application]
 config/name="TBDSpaceRPG"
 run/main_scene="res://Scenes/Flight.tscn"
+mcp_endpoint="http://localhost:8001/mcp"
 
 [dotnet]
 project="TBDSpaceRPG.csproj"

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -484,4 +484,18 @@ To import exported assets into Godot:
 2. Open the Godot project in the Godot 4 editor.
 3. Each `.gltf` file will automatically generate a scene that can be instanced in your C# scripts.
 
+### Configuring the MCP Endpoint
+
+The Godot project reads the MCP endpoint from the `mcp_endpoint` setting in
+`project.godot`. The default is `http://localhost:8001/mcp`. Update this value to
+point at a different server without modifying any scripts.
+
+```ini
+[application]
+mcp_endpoint="http://localhost:8001/mcp"
+```
+
+`McpClient.cs` automatically picks up this value during startup, so changing it
+in the configuration or via the Godot editor is enough to redirect requests.
+
 


### PR DESCRIPTION
## Summary
- add configurable `Endpoint` to `McpClient`
- store default endpoint in Godot project settings
- document how to change the endpoint

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687326d6dd508326886457b340ac87e0