### PR TITLE
Add metrics reset for telemetry

### DIFF
--- a/servers/telemetry/analytics.cjs
+++ b/servers/telemetry/analytics.cjs
@@ -6,6 +6,12 @@ const metrics = {
   latestGeneration: null,
 };
 
+function resetMetrics() {
+  metrics.totalEvents = 0;
+  metrics.eventCounts = {};
+  metrics.latestGeneration = null;
+}
+
 function updateMetrics(event) {
   if (!event || typeof event !== 'object') return;
   if (typeof event.type !== 'string') return;
@@ -21,6 +27,7 @@ function computeMetrics(event) {
 }
 
 function parseLogFile(filePath) {
+  resetMetrics();
   if (!fs.existsSync(filePath)) return metrics;
   const contents = fs.readFileSync(filePath, 'utf8');
   const lines = contents.split(/\r?\n/).filter(Boolean);
@@ -42,5 +49,6 @@ function getMetrics() {
 module.exports = {
   computeMetrics,
   parseLogFile,
+  resetMetrics,
   getMetrics,
 };

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -103,6 +103,12 @@ function post(port, pathName, data) {
     assert.strictEqual(metrics.eventCounts.test, 1);
     assert.strictEqual(metrics.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics.latestGeneration, 1);
+
+    const metrics2 = analytics.parseLogFile(logPath);
+    assert.strictEqual(metrics2.totalEvents, 2);
+    assert.strictEqual(metrics2.eventCounts.test, 1);
+    assert.strictEqual(metrics2.eventCounts.generation_advanced, 1);
+    assert.strictEqual(metrics2.latestGeneration, 1);
     console.log('Tests passed');
     git.kill();
     pg.kill();


### PR DESCRIPTION
## Summary
- add `resetMetrics` helper for telemetry analytics
- clear metrics at the start of `parseLogFile`
- test repeated calls to `parseLogFile`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687326d63f6c8326b545783b7bc37798