### PR TITLE
Update Godot projects to .NET 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,16 @@ jobs:
       - run: dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal
       - run: dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal
 
+  dotnet-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet build Godot/TBDSpaceRPG.csproj --configuration Release
+      - run: dotnet build servers/godot/GodotServer.csproj --configuration Release
+
   unity-tests:
     runs-on: ubuntu-latest
     steps:

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -18,7 +18,7 @@ public partial class McpClient : Control
         var payload = new
         {
             method = "execute_menu_item",
-            params = new { menuPath },
+            @params = new { menuPath },
             id = System.Guid.NewGuid().ToString()
         };
         var json = JsonSerializer.Serialize(payload);

--- a/Godot/TBDSpaceRPG.csproj
+++ b/Godot/TBDSpaceRPG.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Godot.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    "version": "8.0.117"
+  },
+  "msbuild-sdks": {
+    "Godot.NET.Sdk": "4.4.1"
+  }
+}

--- a/servers/godot/GodotServer.csproj
+++ b/servers/godot/GodotServer.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Godot.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
+  </ItemGroup>
 </Project>

--- a/servers/godot/Program.cs
+++ b/servers/godot/Program.cs
@@ -1,49 +1,24 @@
-using Godot;
 using System;
 using System.Text.Json;
-using System.Text;
+using WebSocketSharp;
+using WebSocketSharp.Server;
 
-public partial class McpGodotServer : Node
+public class McpBehavior : WebSocketBehavior
 {
-    private WebSocketServer _server = new();
-
-    public override void _Ready()
+    protected override void OnMessage(MessageEventArgs e)
     {
-        var portEnv = Environment.GetEnvironmentVariable("PORT");
-        if (!int.TryParse(portEnv, out var port))
-            port = 8001;
-
-        _server.Listen(port);
-        GD.Print($"Godot MCP server listening on port {port}");
-        _server.ClientConnected += id => GD.Print($"Client connected: {id}");
-    }
-
-    public override void _Process(double delta)
-    {
-        _server.Poll();
-
-        foreach (var id in _server.GetPeerIds())
+        try
         {
-            var peer = _server.GetPeer(id);
-            while (peer.GetAvailablePacketCount() > 0)
+            var request = JsonSerializer.Deserialize<McpRequest>(e.Data);
+            if (request != null)
             {
-                var bytes = peer.GetPacket();
-                var msg = Encoding.UTF8.GetString(bytes);
-                try
-                {
-                    var request = JsonSerializer.Deserialize<McpRequest>(msg);
-                    if (request != null)
-                    {
-                        var response = new McpResponse { id = request.id };
-                        var respBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(response));
-                        peer.PutPacket(respBytes);
-                    }
-                }
-                catch (Exception e)
-                {
-                    GD.PrintErr($"Failed to process packet: {e.Message}");
-                }
+                var response = new McpResponse { id = request.id };
+                Send(JsonSerializer.Serialize(response));
             }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to process packet: {ex.Message}");
         }
     }
 }
@@ -65,12 +40,15 @@ public static class Program
 {
     public static void Main(string[] args)
     {
-        using var gd = new Godot.Godot();
-        gd.Init();
-        var tree = new SceneTree();
-        var server = new McpGodotServer();
-        tree.Root.AddChild(server);
-        gd.Run(tree);
-        gd.Shutdown();
+        if (!int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var port))
+            port = 8001;
+
+        var server = new WebSocketServer(port);
+        server.AddWebSocketService<McpBehavior>("/");
+        server.Start();
+        Console.WriteLine($"Godot MCP server listening on port {port}");
+        Console.WriteLine("Press Enter to stop the server...");
+        Console.ReadLine();
+        server.Stop();
     }
 }


### PR DESCRIPTION
## Summary
- bump Godot project targets to net8.0
- specify Godot.NET SDK version in `global.json`
- fix `McpClient` keyword usage
- replace Godot server implementation with WebSocketSharp version

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal`
- `dotnet build Godot/TBDSpaceRPG.csproj -c Release`
- `dotnet build servers/godot/GodotServer.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687326d7a4f883269713102c06b92faa