### PR TITLE
Implement KSA protocol translation

### DIFF
--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,13 +1,30 @@
 const http = require('http');
+
 const port = process.env.PORT || 8005;
+
+function translateMcpToKsa(mcp) {
+  return {
+    command: mcp.method,
+    arguments: mcp.params || {},
+    requestId: mcp.id
+  };
+}
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST') {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(body || '{}');
+      try {
+        const mcp = JSON.parse(body || '{}');
+        const ksaRequest = translateMcpToKsa(mcp);
+        const response = { requestId: ksaRequest.requestId, result: { received: ksaRequest } };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(response));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Invalid JSON');
+      }
     });
     return;
   }

--- a/servers/ksa/schema.json
+++ b/servers/ksa/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "KSA Protocol",
+  "definitions": {
+    "request": {
+      "type": "object",
+      "required": ["command", "arguments", "requestId"],
+      "properties": {
+        "command": { "type": "string" },
+        "arguments": { "type": "object" },
+        "requestId": { "type": "string" }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["requestId", "result"],
+      "properties": {
+        "requestId": { "type": "string" },
+        "result": { "type": "object" }
+      }
+    }
+  }
+}

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -84,9 +84,11 @@ function post(port, pathName, data) {
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
     const ksaResponse = await request(ksaPort);
     assert.strictEqual(ksaResponse, 'KSA MCP server placeholder');
-    const echo = await post(ksaPort, '/', { echo: 'test' });
-    assert.strictEqual(echo.statusCode, 200);
-    assert.strictEqual(echo.body, JSON.stringify({ echo: 'test' }));
+    const mcpCmd = { method: 'notify_message', params: { message: 'hi', logType: 'Log' }, id: '42' };
+    const ksaResult = await post(ksaPort, '/', mcpCmd);
+    assert.strictEqual(ksaResult.statusCode, 200);
+    const expectedKsa = { command: 'notify_message', arguments: { message: 'hi', logType: 'Log' }, requestId: '42' };
+    assert.deepStrictEqual(JSON.parse(ksaResult.body), { requestId: '42', result: { received: expectedKsa } });
     const postResult = await post(telemetryPort, '/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
 


### PR DESCRIPTION
## Summary
- define JSON schema for the KSA adapter
- translate MCP commands to KSA schema in the adapter server
- verify translation with updated server tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687332ed640c83269908c1d2c63abc5b