### PR TITLE
Implement simple docking station integration

### DIFF
--- a/Gameplay_Data/game_state.json
+++ b/Gameplay_Data/game_state.json
@@ -1,0 +1,1 @@
+{"upgradeLevel": 0}

--- a/Godot/Scenes/Flight.tscn
+++ b/Godot/Scenes/Flight.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource path="res://Scenes/Ship.tscn" type="PackedScene" id="1"]
 [ext_resource path="res://Scenes/UI/Hud.tscn" type="PackedScene" id="2"]
+[ext_resource path="res://Scenes/StationDock.tscn" type="PackedScene" id="3"]
 
 [node name="Flight" type="Node3D" index="0"]
 
@@ -13,3 +14,5 @@ rotation_degrees = Vector3(10,0,0)
 current = true
 
 [node name="UI" parent="." instance=ExtResource("2")]
+
+[node name="StationDock" parent="." instance=ExtResource("3")]

--- a/Godot/Scenes/StationDock.tscn
+++ b/Godot/Scenes/StationDock.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://Scripts/StationDock.cs" type="Script" id="1"]
+
+[node name="StationDock" type="Control" index="0"]
+script = ExtResource("1")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -16.0
+margin_bottom = -16.0
+
+[node name="DockButton" type="Button" parent="VBox"]
+text = "Dock"
+
+[node name="UpgradeButton" type="Button" parent="VBox"]
+text = "Apply Upgrade"

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -22,7 +22,7 @@ public partial class McpClient : Control
         GetNode<Button>("VBox/RelaunchButton").Pressed += () => _ = SendCommand("Ship/Relaunch");
     }
 
-    private async Task SendCommand(string menuPath)
+    public async Task SendCommand(string menuPath)
     {
         var payload = new
         {

--- a/Godot/Scripts/StationDock.cs
+++ b/Godot/Scripts/StationDock.cs
@@ -1,0 +1,60 @@
+using Godot;
+using System.IO;
+using System.Text.Json;
+
+public partial class StationDock : Control
+{
+    [Export] public string SaveFile = "Gameplay_Data/game_state.json";
+    [Export] public int UpgradeLevel = 0;
+
+    private McpClient _client;
+
+    public override void _Ready()
+    {
+        _client = GetTree().Root.FindChild("HUD", true, false) as McpClient;
+        GetNode<Button>("VBox/DockButton").Pressed += Dock;
+        GetNode<Button>("VBox/UpgradeButton").Pressed += ApplyUpgrade;
+        LoadState();
+    }
+
+    private async void Dock()
+    {
+        if (_client != null)
+            await _client.SendCommand("Dock Ship");
+        SaveState();
+    }
+
+    private async void ApplyUpgrade()
+    {
+        UpgradeLevel++;
+        if (_client != null)
+            await _client.SendCommand("Ship/Upgrade");
+        SaveState();
+    }
+
+    private void SaveState()
+    {
+        Directory.CreateDirectory("Gameplay_Data");
+        var json = JsonSerializer.Serialize(new { upgradeLevel = UpgradeLevel });
+        File.WriteAllText(SaveFile, json);
+    }
+
+    private void LoadState()
+    {
+        if (!File.Exists(SaveFile))
+            return;
+        try
+        {
+            var json = File.ReadAllText(SaveFile);
+            var state = JsonSerializer.Deserialize<UpgradeState>(json);
+            if (state != null)
+                UpgradeLevel = state.upgradeLevel;
+        }
+        catch { }
+    }
+
+    private class UpgradeState
+    {
+        public int upgradeLevel { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `StationDock` Godot script to trigger MCP commands and save upgrade level
- create `StationDock.tscn` and include it in `Flight.tscn`
- expose `SendCommand` in `McpClient`
- add placeholder `game_state.json` for minimal persistence

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/OrbitalMechanics.sln`


------
https://chatgpt.com/codex/tasks/task_e_68742ea3cd5083269cb8322b08766c29