### PR TITLE
Add shared server config for PowerShell utilities

### DIFF
--- a/MCP-PowerShell-Guide.md
+++ b/MCP-PowerShell-Guide.md
@@ -214,6 +214,19 @@ try {
 Write-Output "Script completed successfully"
 ```
 
+## Server Configuration
+
+Ports and runtimes for all MCP scripts are now defined in `server-config.json`.
+Use the `-ServerConfigFile` parameter to point scripts at an alternate file.
+
+```powershell
+# Start the MCP server using settings from a custom file
+.\run-mcp-server.ps1 -ServerConfigFile custom-config.json
+
+# Launch the entire stack using the same shared config
+.\run-all-mcp-servers.ps1 -ServerConfigFile custom-config.json
+```
+
 ## Troubleshooting PowerShell Issues
 
 ### Module Not Found

--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -2,7 +2,8 @@
 param(
     [ValidateSet('unity','godot','ksa')]
     [string]$Engine = 'unity',
-    [string]$ConfigFile = 'engine-config.json'
+    [string]$ConfigFile = 'engine-config.json',
+    [string]$ServerConfigFile = 'server-config.json'
 )
 
 Write-Host "Starting All MCP Servers..." -ForegroundColor Cyan
@@ -27,6 +28,17 @@ if (Test-Path $ConfigFile) {
     }
 }
 
+# Load shared server configuration for ports and runtimes
+$serverCfg = $null
+if (Test-Path $ServerConfigFile) {
+    try {
+        $serverCfg = Get-Content -Path $ServerConfigFile -Raw | ConvertFrom-Json
+        Write-Host "Using server configuration from $ServerConfigFile" -ForegroundColor Green
+    } catch {
+        Write-Warning "Failed to load server configuration from $ServerConfigFile: $_"
+    }
+}
+
 # Determine ports
 $unityPort = 8001
 $gitPort = 8080
@@ -42,6 +54,15 @@ if ($engineCfg) {
     if ($engineCfg.telemetry.port) { $telemetryPort = [int]$engineCfg.telemetry.port }
     if ($engineCfg.mcpproxy.port) { $proxyPort = [int]$engineCfg.mcpproxy.port }
     if ($engineCfg.ksa.port) { $ksaPort = [int]$engineCfg.ksa.port }
+}
+
+if ($serverCfg) {
+    if ($serverCfg.unity.port) { $unityPort = [int]$serverCfg.unity.port }
+    if ($serverCfg.git.port) { $gitPort = [int]$serverCfg.git.port }
+    if ($serverCfg.postgres.port) { $postgresPort = [int]$serverCfg.postgres.port }
+    if ($serverCfg.telemetry.port) { $telemetryPort = [int]$serverCfg.telemetry.port }
+    if ($serverCfg.mcpproxy.port) { $proxyPort = [int]$serverCfg.mcpproxy.port }
+    if ($serverCfg.ksa.port) { $ksaPort = [int]$serverCfg.ksa.port }
 }
 
 # Function to check server ports
@@ -83,7 +104,7 @@ $ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port $ksaPort
 if (-not $unityRunning) {
     Write-Host "Starting Unity MCP Server..." -ForegroundColor Green
     $unityScript = Join-Path $scriptDir "run-mcp-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile -ServerConfigFile $ServerConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Unity MCP Server (already running)" -ForegroundColor Yellow
 }

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -8,7 +8,8 @@ param (
     [string]$Engine = "unity",
     [switch]$Monitor,
     [string]$ConfigFile = ".mcp-server-config.json",
-    [string]$EngineConfigFile = "engine-config.json"
+    [string]$EngineConfigFile = "engine-config.json",
+    [string]$ServerConfigFile = "server-config.json"
 )
 
 # Validate the supplied port number
@@ -29,6 +30,7 @@ $config = @{
     "logFile" = $null
     "nodeEnv" = "production"
     "engine" = $Engine
+    "runtime" = ($Engine -eq 'godot' ? 'dotnet' : 'node')
 }
 $portFromConfig = $false
 
@@ -42,6 +44,7 @@ if (Test-Path $ConfigFile) {
         if ($configData.logFile) { $config.logFile = $configData.logFile }
         if ($configData.nodeEnv) { $config.nodeEnv = $configData.nodeEnv }
         if ($configData.engine) { $config.engine = $configData.engine }
+        if ($configData.runtime) { $config.runtime = $configData.runtime }
         
         Write-Host "Configuration loaded from $ConfigFile" -ForegroundColor Green
     }
@@ -81,6 +84,22 @@ if (Test-Path $EngineConfigFile) {
     }
 }
 
+# Load shared runtime/port settings from the server config file
+if (Test-Path $ServerConfigFile) {
+    try {
+        $serverData = Get-Content -Path $ServerConfigFile -Raw | ConvertFrom-Json
+        $serverEntry = $serverData.$($config.engine)
+        if ($serverEntry) {
+            if (-not $PSBoundParameters.ContainsKey('Port') -and -not $portFromConfig -and $serverEntry.port) {
+                $config.port = [int]$serverEntry.port
+            }
+            if ($serverEntry.engine) { $config.runtime = $serverEntry.engine }
+        }
+    } catch {
+        Write-Warning "Failed to load server configuration from $ServerConfigFile: $_"
+    }
+}
+
 # Use config serverPath if provided, otherwise use default
 if (-not $config.serverPath) {
     if ($config.engine -eq 'godot') {
@@ -95,7 +114,7 @@ if (-not $config.logFile) {
     $config.logFile = Join-Path $projectRoot "mcp-server.log"
 }
 
-if ($config.engine -eq 'godot') {
+if ($config.runtime -eq 'dotnet') {
     try {
         $dotnetVersion = dotnet --version
         Write-Host "dotnet version: $dotnetVersion"
@@ -115,7 +134,7 @@ if ($config.engine -eq 'godot') {
 
 # Validate server path
 if (-not (Test-Path $config.serverPath)) {
-    if ($config.engine -eq 'godot') {
+    if ($config.runtime -eq 'dotnet') {
         Write-Error "Godot MCP Server path not found: $($config.serverPath)"
     } else {
         Write-Error "MCP Server path not found: $($config.serverPath)`nMake sure Unity is open and the MCP package is imported."
@@ -154,13 +173,13 @@ if (Test-PortInUse -Port $config.port) {
 
 # Function to start the MCP server
 function Start-McpServer {
-    Write-Host "Starting MCP Persistent Server using $($config.engine) engine..."
+    Write-Host "Starting MCP Persistent Server using $($config.engine) engine ($($config.runtime))..."
     Write-Host "Starting MCP server on port $($config.port)..."
 
     try {
         Push-Location $config.serverPath
 
-        if ($config.engine -eq 'godot') {
+        if ($config.runtime -eq 'dotnet') {
             $env:PORT = $config.port.ToString()
             $processInfo = Start-Process -FilePath "dotnet" -ArgumentList "run --project GodotServer.csproj --no-build" -RedirectStandardOutput $config.logFile -RedirectStandardError $config.logFile -NoNewWindow -PassThru
         }

--- a/server-config.json
+++ b/server-config.json
@@ -1,0 +1,9 @@
+{
+  "unity": { "port": 8001, "engine": "node" },
+  "godot": { "port": 8001, "engine": "dotnet" },
+  "git": { "port": 8080, "engine": "node" },
+  "postgres": { "port": 8003, "engine": "node" },
+  "telemetry": { "port": 8090, "engine": "node" },
+  "mcpproxy": { "port": 8004, "engine": "node" },
+  "ksa": { "port": 8005, "engine": "node" }
+}


### PR DESCRIPTION
## Summary
- introduce `server-config.json` for ports and engine runtime
- update `run-mcp-server.ps1` to load runtime/port from config
- update `run-all-mcp-servers.ps1` to use the new config
- document `-ServerConfigFile` option in `MCP-PowerShell-Guide.md`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68742ea4a7148326ae4fb6da424d28fc