### PR TITLE
Add analytics tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prelint": "npm ci",
     "pretest": "npm ci",
-    "test": "node tests/server.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
+    "test": "node tests/server.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
     "lint": "eslint servers tests"
   },
   "devDependencies": {

--- a/tests/analytics.test.cjs
+++ b/tests/analytics.test.cjs
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const analytics = require('../servers/telemetry/analytics.cjs');
+
+const logPath = path.join(__dirname, 'analytics_test.log');
+if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+
+(async () => {
+  try {
+    const lines = [
+      JSON.stringify({ type: 'test' }),
+      'not json',
+      JSON.stringify({ type: 'generation_advanced', generation: 3 })
+    ].join('\n');
+    fs.writeFileSync(logPath, lines);
+
+    const metrics = analytics.parseLogFile(logPath);
+    assert.strictEqual(metrics.totalEvents, 2);
+    assert.strictEqual(metrics.eventCounts.test, 1);
+    assert.strictEqual(metrics.eventCounts.generation_advanced, 1);
+    assert.strictEqual(metrics.latestGeneration, 3);
+
+    const metricsAgain = analytics.parseLogFile(logPath);
+    assert.deepStrictEqual(metricsAgain, metrics);
+
+    analytics.resetMetrics();
+    analytics.computeMetrics({ type: 'generation_advanced', generation: 5 });
+    assert.strictEqual(analytics.getMetrics().latestGeneration, 5);
+
+    console.log('Analytics tests passed');
+  } finally {
+    if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+  }
+})();


### PR DESCRIPTION
## Summary
- add standalone analytics tests covering invalid JSON and multiple reads
- update npm test script to run the new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68742ea6615c832688838ad41935cc81