### PR TITLE
Add WebSocket server tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           dotnet-version: '8.0.x'
       - run: dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal
       - run: dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal
+      - run: dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal
 
   dotnet-build:
     runs-on: ubuntu-latest

--- a/servers/godot.Tests/GlobalUsings.cs
+++ b/servers/godot.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/servers/godot.Tests/GodotServer.Tests.csproj
+++ b/servers/godot.Tests/GodotServer.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../godot/GodotServer.csproj" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/servers/godot.Tests/WebSocketTests.cs
+++ b/servers/godot.Tests/WebSocketTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WebSocketSharp.Server;
+
+namespace GodotServer.Tests;
+
+public class WebSocketTests
+{
+    private WebSocketServer? _server;
+    private int _port;
+
+    [SetUp]
+    public void Setup()
+    {
+        _port = GetFreePort();
+        _server = new WebSocketServer(_port);
+        _server.AddWebSocketService<McpBehavior>("/");
+        _server.Start();
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _server?.Stop();
+    }
+
+    [Test]
+    public async Task HandshakeSucceeds()
+    {
+        using var ws = new ClientWebSocket();
+        var uri = new Uri($"ws://localhost:{_port}/");
+        await ws.ConnectAsync(uri, CancellationToken.None);
+        Assert.That(ws.State, Is.EqualTo(WebSocketState.Open));
+    }
+
+    [Test]
+    public async Task RequestRespondsWithOk()
+    {
+        using var ws = new ClientWebSocket();
+        var uri = new Uri($"ws://localhost:{_port}/");
+        await ws.ConnectAsync(uri, CancellationToken.None);
+
+        var reqJson = "{\"type\":\"test\",\"id\":\"42\",\"parameters\":{}}";
+        var bytes = Encoding.UTF8.GetBytes(reqJson);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+
+        var buffer = new byte[1024];
+        var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+        var resp = Encoding.UTF8.GetString(buffer, 0, result.Count);
+        var doc = JsonDocument.Parse(resp);
+        Assert.That(doc.RootElement.GetProperty("id").GetString(), Is.EqualTo("42"));
+        Assert.That(doc.RootElement.GetProperty("result").GetProperty("status").GetString(), Is.EqualTo("ok"));
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}


### PR DESCRIPTION
## Summary
- add new NUnit project to test `servers/godot`
- verify WebSocket handshake and simple request/response
- run the new tests in CI

## Testing
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity minimal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity minimal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68742ea568888326a6435d1ddf735066