### PR TITLE
Add placeholder MCP Proxy server

### DIFF
--- a/servers/mcpProxy/dist/src/index.js
+++ b/servers/mcpProxy/dist/src/index.js
@@ -1,0 +1,14 @@
+const http = require('http');
+
+const port = process.env.PORT || 8004;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('MCP Proxy server placeholder');
+});
+
+server.listen(port, () => {
+  console.log(`MCP Proxy server listening on port ${port}`);
+});
+
+server.on('error', err => console.error(err));

--- a/servers/mcpProxy/package.json
+++ b/servers/mcpProxy/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mcp-proxy",
+  "version": "0.1.0",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "start": "node dist/src/index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal MCP Proxy server placeholder under `servers/mcpProxy`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e9ed6c65083268c13ee2fbd092790