### PR TITLE
Ensure CelestialBody has default OrbitData

### DIFF
--- a/src/OrbitalMechanics/CelestialBody.cs
+++ b/src/OrbitalMechanics/CelestialBody.cs
@@ -16,6 +16,12 @@ namespace OrbitalMechanics
 
         private void Awake()
         {
+            // Ensure we always have valid orbit data
+            if (initialOrbit == null)
+            {
+                initialOrbit = new OrbitData();
+            }
+
             // Register this body with the global orbit manager if present
             if (OrbitManager.Instance != null)
             {


### PR DESCRIPTION
## Summary
- initialize `initialOrbit` in `CelestialBody.Awake`

## Testing
- `npm test`
- `npm run lint`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --nologo --verbosity quiet`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --nologo --verbosity quiet`


------
https://chatgpt.com/codex/tasks/task_e_687e9ed5fc1c83268a41f57dac0eef56