### PR TITLE
Switch Godot server to built-in WebSocket

### DIFF
--- a/servers/godot.Tests/WebSocketTests.cs
+++ b/servers/godot.Tests/WebSocketTests.cs
@@ -4,28 +4,25 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using WebSocketSharp.Server;
-
 namespace GodotServer.Tests;
 
 public class WebSocketTests
 {
-    private WebSocketServer? _server;
+    private SimpleWebSocketServer? _server;
     private int _port;
 
     [SetUp]
     public void Setup()
     {
         _port = GetFreePort();
-        _server = new WebSocketServer(_port);
-        _server.AddWebSocketService<McpBehavior>("/");
+        _server = new SimpleWebSocketServer(_port);
         _server.Start();
     }
 
     [TearDown]
     public void Teardown()
     {
-        _server?.Stop();
+        _server?.Dispose();
     }
 
     [Test]

--- a/servers/godot/GodotServer.csproj
+++ b/servers/godot/GodotServer.csproj
@@ -3,7 +3,4 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
-  </ItemGroup>
 </Project>

--- a/servers/godot/Program.cs
+++ b/servers/godot/Program.cs
@@ -1,39 +1,128 @@
 using System;
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
 using System.Text.Json;
-using WebSocketSharp;
-using WebSocketSharp.Server;
+using System.Threading;
+using System.Threading.Tasks;
 
-public class McpBehavior : WebSocketBehavior
-{
-    protected override void OnMessage(MessageEventArgs e)
-    {
-        try
-        {
-            var request = JsonSerializer.Deserialize<McpRequest>(e.Data);
-            if (request != null)
-            {
-                var response = new McpResponse { id = request.id };
-                Send(JsonSerializer.Serialize(response));
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Failed to process packet: {ex.Message}");
-        }
-    }
-}
+#nullable enable
 
 public class McpRequest
 {
-    public string type { get; set; }
-    public string id { get; set; }
+    public string type { get; set; } = string.Empty;
+    public string id { get; set; } = string.Empty;
     public JsonElement parameters { get; set; }
 }
 
 public class McpResponse
 {
-    public string id { get; set; }
+    public string id { get; set; } = string.Empty;
     public object result { get; set; } = new { status = "ok" };
+}
+
+public class SimpleWebSocketServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _listenTask;
+
+    public int Port { get; }
+
+    public SimpleWebSocketServer(int port)
+    {
+        Port = port;
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"http://+:{port}/");
+    }
+
+    public void Start()
+    {
+        _listener.Start();
+        _listenTask = Task.Run(() => ListenLoop(_cts.Token));
+    }
+
+    private async Task ListenLoop(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            HttpListenerContext ctx;
+            try
+            {
+                ctx = await _listener.GetContextAsync();
+            }
+            catch (HttpListenerException) when (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (!ctx.Request.IsWebSocketRequest)
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.Close();
+                continue;
+            }
+
+            var wsContext = await ctx.AcceptWebSocketAsync(null);
+            _ = Task.Run(() => HandleConnection(wsContext.WebSocket, token));
+        }
+    }
+
+    private async Task HandleConnection(WebSocket socket, CancellationToken token)
+    {
+        var buffer = new byte[1024];
+        while (socket.State == WebSocketState.Open && !token.IsCancellationRequested)
+        {
+            WebSocketReceiveResult result;
+            try
+            {
+                result = await socket.ReceiveAsync(buffer, token);
+            }
+            catch
+            {
+                break;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", token);
+                break;
+            }
+
+            var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            try
+            {
+                var request = JsonSerializer.Deserialize<McpRequest>(json);
+                if (request != null)
+                {
+                    var response = new McpResponse { id = request.id };
+                    var respJson = JsonSerializer.Serialize(response);
+                    var respBytes = Encoding.UTF8.GetBytes(respJson);
+                    await socket.SendAsync(respBytes, WebSocketMessageType.Text, true, token);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to process packet: {ex.Message}");
+            }
+        }
+    }
+
+    public void Stop()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        try
+        {
+            _listenTask?.Wait();
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
 }
 
 public static class Program
@@ -43,8 +132,7 @@ public static class Program
         if (!int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var port))
             port = 8001;
 
-        var server = new WebSocketServer(port);
-        server.AddWebSocketService<McpBehavior>("/");
+        using var server = new SimpleWebSocketServer(port);
         server.Start();
         Console.WriteLine($"Godot MCP server listening on port {port}");
         Console.WriteLine("Press Enter to stop the server...");


### PR DESCRIPTION
## Summary
- implement a simple WebSocket server using `System.Net.WebSockets`
- drop `WebSocketSharp` dependency
- update tests to use the new server
- clean up the WebSocket server configuration

## Testing
- `npm run lint`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_687e9ed725b883269472cb8aac646044