### PR TITLE
Add unified export script

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -482,6 +482,16 @@ The Unity project includes lightweight exporters that run without opening the ed
 
 This script builds `Exporters.csproj` and writes a sample `.gltf` file to `Assets_glTF/` and a JSON data file to `Gameplay_Data/`. Integrate it into your CI pipeline to regenerate assets automatically.
 
+### Unified Export Tool
+
+Run the following PowerShell script to execute the exporters and automatically move the outputs into the Godot project:
+
+```powershell
+./run-exporters-to-godot.ps1
+```
+
+The script copies glTF files into `Godot/Assets_glTF/` and gameplay data into `Godot/Gameplay_Data/` so the assets are ready for import when you open the Godot editor.
+
 ### Starting Servers for Godot
 Run all MCP servers configured for Godot with:
 ```powershell
@@ -489,7 +499,7 @@ Run all MCP servers configured for Godot with:
 ```
 
 To import exported assets into Godot:
-1. Copy or move the contents of `Assets_glTF/` into the `Godot` project folder.
+1. Run `./run-exporters-to-godot.ps1`.
 2. Open the Godot project in the Godot 4 editor.
 3. Each `.gltf` file will automatically generate a scene that can be instanced in your C# scripts.
 

--- a/run-exporters-to-godot.ps1
+++ b/run-exporters-to-godot.ps1
@@ -1,0 +1,27 @@
+param(
+    [string]$GodotPath = "Godot"
+)
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $repoRoot
+try {
+    # Run the Unity exporters
+    & './TBD SpaceGame/Assets/Editor/run-exporters.sh'
+
+    $gltfSource = Join-Path $repoRoot 'Assets_glTF'
+    $dataSource = Join-Path $repoRoot 'Gameplay_Data'
+
+    $gltfDest = Join-Path $GodotPath 'Assets_glTF'
+    $dataDest = Join-Path $GodotPath 'Gameplay_Data'
+
+    New-Item -ItemType Directory -Force -Path $gltfDest | Out-Null
+    New-Item -ItemType Directory -Force -Path $dataDest | Out-Null
+
+    Copy-Item -Path (Join-Path $gltfSource '*') -Destination $gltfDest -Recurse -Force
+    Copy-Item -Path (Join-Path $dataSource '*') -Destination $dataDest -Recurse -Force
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Exported assets copied to $GodotPath"


### PR DESCRIPTION
## Summary
- add a script to run Unity exporters and copy the results into the Godot project
- document the unified export script in the README

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_687ea6cb901083269989f4f88a6d8fab