### PR TITLE
Set separate default ports for Unity and Godot

### DIFF
--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 public partial class McpClient : Control
 {
-    [Export] public string Endpoint = "http://localhost:8001/mcp";
+    [Export] public string Endpoint = "http://localhost:8002/mcp";
 
     public override void _Ready()
     {

--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -3,7 +3,7 @@
 [application]
 config/name="TBDSpaceRPG"
 run/main_scene="res://Scenes/Flight.tscn"
-mcp_endpoint="http://localhost:8001/mcp"
+mcp_endpoint="http://localhost:8002/mcp"
 
 [dotnet]
 project="TBDSpaceRPG.csproj"

--- a/engine-config.json
+++ b/engine-config.json
@@ -4,7 +4,7 @@
     "directory": "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server"
   },
   "godot": {
-    "port": 8001,
+    "port": 8002,
     "directory": "servers/godot"
   },
   "git": {

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -1,9 +1,9 @@
 # run-mcp-server.ps1
-# Purpose: Starts the MCP Unity server with proper environment configuration
-# Usage: .\run-mcp-server.ps1 [-Port <port_number>] [-Monitor] [-ConfigFile <path>] [-EngineConfigFile <path>]
+# Purpose: Starts the MCP server for the selected engine with proper environment configuration
+# Usage: .\run-mcp-server.ps1 [-Port <port_number>] [-Engine unity|godot] [-Monitor] [-ConfigFile <path>] [-EngineConfigFile <path>]
 
 param (
-    [int]$Port = 8001,
+    [int]$Port = 0,
     [ValidateSet("unity","godot")]
     [string]$Engine = "unity",
     [switch]$Monitor,
@@ -18,9 +18,8 @@ function Test-ValidPort {
     return ($Port -ge 1 -and $Port -le 65535)
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($Port -ne 0 -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
-
 }
 
 # Load configuration from file if it exists
@@ -97,6 +96,15 @@ if (Test-Path $ServerConfigFile) {
         }
     } catch {
         Write-Warning "Failed to load server configuration from $ServerConfigFile: $_"
+    }
+}
+
+# Ensure a valid port is set, falling back to engine defaults
+if (-not (Test-ValidPort -Port $config.port)) {
+    if ($config.engine -eq 'godot') {
+        $config.port = 8002
+    } else {
+        $config.port = 8001
     }
 }
 

--- a/server-config.json
+++ b/server-config.json
@@ -1,6 +1,6 @@
 {
   "unity": { "port": 8001, "engine": "node" },
-  "godot": { "port": 8001, "engine": "dotnet" },
+  "godot": { "port": 8002, "engine": "dotnet" },
   "git": { "port": 8080, "engine": "node" },
   "postgres": { "port": 8003, "engine": "node" },
   "telemetry": { "port": 8090, "engine": "node" },

--- a/servers/godot/Program.cs
+++ b/servers/godot/Program.cs
@@ -130,7 +130,7 @@ public static class Program
     public static void Main(string[] args)
     {
         if (!int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var port))
-            port = 8001;
+            port = 8002;
 
         using var server = new SimpleWebSocketServer(port);
         server.Start();


### PR DESCRIPTION
## Summary
- assign Godot server port 8002 in engine and server configs
- update Godot project and client to match new port
- default to port 8002 for Godot server code
- update run-mcp-server.ps1 to use engine-specific defaults

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/OrbitalMechanics.sln`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_687ea6cbd3588326b8df06aa5e238003