### PR TITLE
Add AI Director server and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prelint": "npm ci",
     "pretest": "npm ci",
-    "test": "node tests/server.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
+    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
     "lint": "eslint servers tests"
   },
   "devDependencies": {

--- a/servers/aidirector/index.cjs
+++ b/servers/aidirector/index.cjs
@@ -1,0 +1,35 @@
+const http = require('http');
+
+const port = process.env.PORT || 8100;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('AI Director server placeholder');
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/command') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ received: data }));
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Invalid JSON');
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+server.listen(port, () => {
+  console.log(`AI Director server listening on port ${port}`);
+});
+server.on('error', err => console.error(err));

--- a/tests/aidirector.test.cjs
+++ b/tests/aidirector.test.cjs
@@ -1,0 +1,50 @@
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+const assert = require('assert');
+
+function startServer(relativePath, port) {
+  const fullPath = path.join(__dirname, '..', relativePath);
+  const env = { ...process.env, PORT: String(port) };
+  return spawn('node', [fullPath], { env });
+}
+
+function request(port, options = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: 'localhost', port, ...options }, res => {
+      let data = '';
+      res.on('data', c => { data += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    if (options.method === 'POST' && options.body) {
+      req.write(JSON.stringify(options.body));
+    }
+    req.end();
+  });
+}
+
+(async () => {
+  const port = 8101;
+  const server = startServer('servers/aidirector/index.cjs', port);
+  try {
+    // Wait for server to be ready
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const root = await request(port);
+    assert.strictEqual(root.body, 'AI Director server placeholder');
+
+    const cmd = await request(port, {
+      method: 'POST',
+      path: '/command',
+      headers: { 'Content-Type': 'application/json' },
+      body: { action: 'test' },
+    });
+    assert.strictEqual(cmd.statusCode, 200);
+    assert.deepStrictEqual(JSON.parse(cmd.body), { received: { action: 'test' } });
+
+    console.log('AI Director tests passed');
+  } finally {
+    server.kill();
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add AI Director server stub
- add matching AI Director tests
- run new test as part of `npm test`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb41184408326b86b20a767264b06