### PR TITLE
Extend game state schema

### DIFF
--- a/Gameplay_Data/game_state.json
+++ b/Gameplay_Data/game_state.json
@@ -1,1 +1,5 @@
-{"upgradeLevel": 0}
+{
+  "upgradeLevel": 0,
+  "shipPosition": {"X": 0, "Y": 0, "Z": 0},
+  "crewStats": {"crewCount": 0, "morale": 0}
+}

--- a/Godot/Scripts/StationDock.cs
+++ b/Godot/Scripts/StationDock.cs
@@ -1,11 +1,11 @@
 using Godot;
-using System.IO;
-using System.Text.Json;
 
 public partial class StationDock : Control
 {
     [Export] public string SaveFile = "Gameplay_Data/game_state.json";
     [Export] public int UpgradeLevel = 0;
+    [Export] public Vector3 ShipPosition = Vector3.Zero;
+    [Export] public CrewStats CrewStats = new CrewStats();
 
     private McpClient _client;
 
@@ -34,27 +34,20 @@ public partial class StationDock : Control
 
     private void SaveState()
     {
-        Directory.CreateDirectory("Gameplay_Data");
-        var json = JsonSerializer.Serialize(new { upgradeLevel = UpgradeLevel });
-        File.WriteAllText(SaveFile, json);
+        var state = new GameState
+        {
+            upgradeLevel = UpgradeLevel,
+            shipPosition = new Vector3Data { X = ShipPosition.X, Y = ShipPosition.Y, Z = ShipPosition.Z },
+            crewStats = CrewStats
+        };
+        state.Save(SaveFile);
     }
 
     private void LoadState()
     {
-        if (!File.Exists(SaveFile))
-            return;
-        try
-        {
-            var json = File.ReadAllText(SaveFile);
-            var state = JsonSerializer.Deserialize<UpgradeState>(json);
-            if (state != null)
-                UpgradeLevel = state.upgradeLevel;
-        }
-        catch { }
-    }
-
-    private class UpgradeState
-    {
-        public int upgradeLevel { get; set; }
+        var state = GameState.Load(SaveFile);
+        UpgradeLevel = state.upgradeLevel;
+        ShipPosition = new Vector3(state.shipPosition.X, state.shipPosition.Y, state.shipPosition.Z);
+        CrewStats = state.crewStats;
     }
 }

--- a/csharp/GameState.Tests/GameState.Tests.csproj
+++ b/csharp/GameState.Tests/GameState.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../GameState/GameState.csproj" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/csharp/GameState.Tests/GlobalUsings.cs
+++ b/csharp/GameState.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/csharp/GameState.Tests/SerializationTests.cs
+++ b/csharp/GameState.Tests/SerializationTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using System.IO;
+
+public class SerializationTests
+{
+    private const string SavePath = "Gameplay_Data/test_state.json";
+
+    [TearDown]
+    public void Cleanup()
+    {
+        if (File.Exists(SavePath))
+            File.Delete(SavePath);
+    }
+
+    [Test]
+    public void SaveAndLoad_PreservesData()
+    {
+        var state = new GameState
+        {
+            upgradeLevel = 3,
+            shipPosition = new Vector3Data { X = 1, Y = 2, Z = 3 },
+            crewStats = new CrewStats { crewCount = 5, morale = 80 }
+        };
+
+        state.Save(SavePath);
+        Assert.IsTrue(File.Exists(SavePath));
+
+        var loaded = GameState.Load(SavePath);
+        Assert.AreEqual(state.upgradeLevel, loaded.upgradeLevel);
+        Assert.AreEqual(state.shipPosition.X, loaded.shipPosition.X);
+        Assert.AreEqual(state.shipPosition.Y, loaded.shipPosition.Y);
+        Assert.AreEqual(state.shipPosition.Z, loaded.shipPosition.Z);
+        Assert.AreEqual(state.crewStats.crewCount, loaded.crewStats.crewCount);
+        Assert.AreEqual(state.crewStats.morale, loaded.crewStats.morale);
+    }
+}

--- a/csharp/GameState/GameState.csproj
+++ b/csharp/GameState/GameState.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../src/GameState/GameState.cs" />
+    <Compile Include="../GodotStubs/Godot.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/GameState/GameState.cs
+++ b/src/GameState/GameState.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Text.Json;
+
+public struct Vector3Data
+{
+    public float X { get; set; }
+    public float Y { get; set; }
+    public float Z { get; set; }
+}
+
+public class GameState
+{
+    public int upgradeLevel { get; set; }
+    public Vector3Data shipPosition { get; set; }
+    public CrewStats crewStats { get; set; } = new CrewStats();
+
+    public static GameState Load(string path)
+    {
+        if (!File.Exists(path))
+            return new GameState();
+        try
+        {
+            var json = File.ReadAllText(path);
+            var state = JsonSerializer.Deserialize<GameState>(json);
+            return state ?? new GameState();
+        }
+        catch
+        {
+            return new GameState();
+        }
+    }
+
+    public void Save(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonSerializer.Serialize(this);
+        File.WriteAllText(path, json);
+    }
+}
+
+public class CrewStats
+{
+    public int crewCount { get; set; }
+    public int morale { get; set; }
+}


### PR DESCRIPTION
## Summary
- expand the default `game_state.json` to hold position and crew data
- implement `GameState` library for JSON serialization
- update `StationDock` to persist ship position and crew stats
- add new unit tests verifying serialization

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/GameState.Tests/GameState.Tests.csproj --verbosity minimal`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity minimal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity minimal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_687eb4126f1c83268dc00d4a0b0c10f0