### PR TITLE
Add Godot .NET tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,17 @@ jobs:
       - run: dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal
       - run: dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal
       - run: dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal
+      - name: Download Godot
+        run: |
+          curl -L -o godot.zip https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_mono_linux_x86_64.zip
+          unzip -q godot.zip -d godot
+          mv godot/Godot_v4.4.1-stable_mono_linux_x86_64/GodotSharp godot/
+          mv godot/Godot_v4.4.1-stable_mono_linux_x86_64/Godot_v4.4.1-stable_mono_linux.x86_64 godot/godot
+          chmod +x godot/godot
+      - name: Build Godot test project
+        run: dotnet build Godot.Tests/Godot.Tests.csproj
+      - name: Run Godot tests
+        run: ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish
 
   dotnet-build:
     runs-on: ubuntu-latest

--- a/Godot.Tests/Godot.Tests.csproj
+++ b/Godot.Tests/Godot.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Godot.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>Godot.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Chickensoft.GoDotTest" Version="1.7.4" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Godot/TBDSpaceRPG.csproj" />
+  </ItemGroup>
+</Project>

--- a/Godot.Tests/project.godot
+++ b/Godot.Tests/project.godot
@@ -1,0 +1,14 @@
+; Engine configuration file
+
+[application]
+config/name="Godot.Tests"
+run/main_scene="res://test/Tests.tscn"
+
+[dotnet]
+project="Godot.Tests.csproj"
+
+[input]
+move_forward={"deadzone":0.5,"events":[{"type":"key","scancode":87}]}
+move_backward={"deadzone":0.5,"events":[{"type":"key","scancode":83}]}
+turn_left={"deadzone":0.5,"events":[{"type":"key","scancode":65}]}
+turn_right={"deadzone":0.5,"events":[{"type":"key","scancode":68}]}

--- a/Godot.Tests/test/Tests.cs
+++ b/Godot.Tests/test/Tests.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+using Godot;
+using Chickensoft.GoDotTest;
+
+public partial class Tests : Node2D
+{
+    public override void _Ready()
+        => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this);
+}

--- a/Godot.Tests/test/Tests.tscn
+++ b/Godot.Tests/test/Tests.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://test/Tests.cs" id="1"]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource("1")

--- a/Godot.Tests/test/src/McpClientTests.cs
+++ b/Godot.Tests/test/src/McpClientTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public class McpClientTests : TestClass {
+    public McpClientTests(Node scene) : base(scene) { }
+
+    [Test]
+    public async Task SendCommand_PostsPayload() {
+        int port = GetFreePort();
+        string url = $"http://localhost:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(url);
+        listener.Start();
+
+        var client = new McpClient { Endpoint = url };
+        TestScene.AddChild(client);
+        var sendTask = client.SendCommand("Test/Path");
+
+        var context = await listener.GetContextAsync();
+        string body;
+        using (var reader = new StreamReader(context.Request.InputStream))
+            body = await reader.ReadToEndAsync();
+        context.Response.StatusCode = 200;
+        context.Response.Close();
+        listener.Stop();
+
+        await sendTask;
+        body.ShouldContain("\"menuPath\":\"Test/Path\"");
+    }
+
+    private static int GetFreePort() {
+        var l = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        int p = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return p;
+    }
+}

--- a/Godot.Tests/test/src/SpaceshipMovementTests.cs
+++ b/Godot.Tests/test/src/SpaceshipMovementTests.cs
@@ -1,0 +1,31 @@
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public class SpaceshipMovementTests : TestClass {
+    public SpaceshipMovementTests(Node scene) : base(scene) { }
+
+    [Test]
+    public void PhysicsProcess_ForwardActionAppliesThrust() {
+        var movement = new SpaceshipMovement();
+        Input.ActionPress("move_forward");
+        movement.ThrustForce = 5f;
+        movement.MaxSpeed = 100f;
+        movement._PhysicsProcess(1.0);
+        movement.Velocity.X.ShouldBe(0f);
+        movement.Velocity.Y.ShouldBe(0f);
+        movement.Velocity.Z.ShouldBe(-5f);
+        Input.ActionRelease("move_forward");
+    }
+
+    [Test]
+    public void PhysicsProcess_ClampsVelocity() {
+        var movement = new SpaceshipMovement();
+        Input.ActionPress("move_forward");
+        movement.ThrustForce = 50f;
+        movement.MaxSpeed = 10f;
+        movement._PhysicsProcess(1.0);
+        movement.Velocity.Length().ShouldBe(10f);
+        Input.ActionRelease("move_forward");
+    }
+}

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -11,10 +11,10 @@ public partial class McpClient : Control
         if (ProjectSettings.HasSetting("application/mcp_endpoint"))
         {
             var cfg = ProjectSettings.GetSetting("application/mcp_endpoint");
-            if (cfg is StringName sn)
-                Endpoint = sn.ToString();
-            else if (cfg is string str)
-                Endpoint = str;
+            if (cfg.VariantType == Variant.Type.StringName)
+                Endpoint = ((StringName)cfg).ToString();
+            else if (cfg.VariantType == Variant.Type.String)
+                Endpoint = (string)cfg;
         }
 
         GetNode<Button>("VBox/DockButton").Pressed += () => _ = SendCommand("Dock Ship");


### PR DESCRIPTION
## Summary
- create GoDotTest-based project under `Godot.Tests`
- write tests for `McpClient` and `SpaceshipMovement`
- add project Godot configuration and runner scene
- download Godot in CI and run tests with `GoDotTest`

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal`
- `./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish`

------
https://chatgpt.com/codex/tasks/task_e_687eb413723083268ef30b82191c6965