### PR TITLE
Read MCP endpoint from config

### DIFF
--- a/execute-mcp-command.ps1
+++ b/execute-mcp-command.ps1
@@ -1,7 +1,9 @@
 # PowerShell script to execute MCP commands
 param (
     [Parameter(Mandatory=$true)]
-    [string]$menuPath
+    [string]$menuPath,
+    [string]$Endpoint,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 # Output what we're doing
@@ -12,7 +14,25 @@ function Test-ValidPort {
     return $Port -ge 1 -and $Port -le 65535
 }
 
-$uri = "http://localhost:8001/mcp"
+$uri = $null
+
+if ($PSBoundParameters.ContainsKey('Endpoint')) {
+    $uri = $Endpoint
+} elseif (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.unity -and $cfg.unity.port) {
+            $uri = "http://localhost:$($cfg.unity.port)/mcp"
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
+}
+
+if (-not $uri) {
+    $uri = "http://localhost:8001/mcp"
+}
+
 $port = ([System.Uri]$uri).Port
 if (-not (Test-ValidPort -Port $port)) {
     Write-Error "Invalid port: $port"
@@ -30,7 +50,7 @@ $payload = @{
 
 # Execute the command using Invoke-WebRequest
 try {
-    $result = Invoke-WebRequest -Uri "http://localhost:8001/mcp" -Method Post -Body $payload -ContentType "application/json"
+    $result = Invoke-WebRequest -Uri $uri -Method Post -Body $payload -ContentType "application/json"
     Write-Host "Result: $($result.Content)"
 }
 catch {

--- a/execute-mcp-message.ps1
+++ b/execute-mcp-message.ps1
@@ -1,7 +1,9 @@
 # PowerShell script to send a test message to Unity console
 param (
     [Parameter(Mandatory=$true)]
-    [string]$message
+    [string]$message,
+    [string]$Endpoint,
+    [string]$ConfigFile = "engine-config.json"
 )
 
 # Output what we're doing
@@ -12,7 +14,25 @@ function Test-ValidPort {
     return $Port -ge 1 -and $Port -le 65535
 }
 
-$uri = "http://localhost:8001/mcp"
+$uri = $null
+
+if ($PSBoundParameters.ContainsKey('Endpoint')) {
+    $uri = $Endpoint
+} elseif (Test-Path $ConfigFile) {
+    try {
+        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+        if ($cfg.unity -and $cfg.unity.port) {
+            $uri = "http://localhost:$($cfg.unity.port)/mcp"
+        }
+    } catch {
+        Write-Warning "Failed to load engine config from $ConfigFile: $_"
+    }
+}
+
+if (-not $uri) {
+    $uri = "http://localhost:8001/mcp"
+}
+
 $port = ([System.Uri]$uri).Port
 if (-not (Test-ValidPort -Port $port)) {
     Write-Error "Invalid port: $port"
@@ -31,7 +51,7 @@ $payload = @{
 
 # Execute the command using Invoke-WebRequest
 try {
-    $result = Invoke-WebRequest -Uri "http://localhost:8001/mcp" -Method Post -Body $payload -ContentType "application/json"
+    $result = Invoke-WebRequest -Uri $uri -Method Post -Body $payload -ContentType "application/json"
     Write-Host "Result: $($result.Content)"
 }
 catch {


### PR DESCRIPTION
## Summary
- load endpoint from `engine-config.json` or a `-Endpoint` argument
- default to `http://localhost:8001/mcp`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68804149d7c08326b8669ee8a0aabab3