### PR TITLE
Add Godot test script

### DIFF
--- a/Godot/Scripts/StationDock.cs
+++ b/Godot/Scripts/StationDock.cs
@@ -5,7 +5,7 @@ public partial class StationDock : Control
     [Export] public string SaveFile = "Gameplay_Data/game_state.json";
     [Export] public int UpgradeLevel = 0;
     [Export] public Vector3 ShipPosition = Vector3.Zero;
-    [Export] public CrewStats CrewStats = new CrewStats();
+    public CrewStats CrewStats = new CrewStats();
 
     private McpClient _client;
 

--- a/Godot/TBDSpaceRPG.csproj
+++ b/Godot/TBDSpaceRPG.csproj
@@ -2,5 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
+</PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../src/GameState/GameState.cs" />
+  </ItemGroup>
 </Project>

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -227,9 +227,22 @@ public class McpServerAutoRestarter
 
 ## Running Tests
 
-All automated tests use PowerShell scripts. Ensure that the `pwsh` command is available before running tests.
+Install dependencies with `npm ci` before executing the test scripts. The test suite includes Node-based tests, optional Unity tests, and a Godot test project that requires the `dotnet` CLI.
 
-Run `npm ci` to install Node.js dependencies before executing the test script.
+Run all tests with:
+
+```sh
+npm test
+```
+
+To run only the Godot tests:
+
+```sh
+npm run test:godot
+```
+This command builds the Godot test project using `dotnet` and then executes the tests in a headless Godot instance.
+
+You can still invoke the original PowerShell script if needed:
 
 ```pwsh
 pwsh -File tests/test-servers.ps1

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prelint": "npm ci",
     "pretest": "npm ci",
-    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi",
+    "test:godot": "dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish",
+    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
     "lint": "eslint servers tests"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- support Godot tests via new `test:godot` npm script
- run Godot tests from the main `test` script
- document running tests with npm in the MCP integration guide
- compile GameState sources in the Godot project
- fix build error in StationDock script

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68804149612883268bab3474908e9dd2