### PR TITLE
Add stub MCP server endpoints and postgres CRUD

### DIFF
--- a/servers/git/index.cjs
+++ b/servers/git/index.cjs
@@ -1,7 +1,27 @@
 const http = require('http');
 const port = process.env.PORT || 8080;
 
+function sendJson(res, obj) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
 const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/init') {
+    sendJson(res, { initialized: true });
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/commit') {
+    sendJson(res, { committed: true });
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/status') {
+    sendJson(res, { status: 'clean' });
+    return;
+  }
+
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Git MCP server placeholder');
 });

--- a/servers/postgres/index.cjs
+++ b/servers/postgres/index.cjs
@@ -1,9 +1,84 @@
 const http = require('http');
 const port = process.env.PORT || 8003;
 
+const crew = [];
+let nextId = 1;
+
+function sendJson(res, code, obj) {
+  res.writeHead(code, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+function handleCrew(req, res) {
+  const idMatch = req.url.match(/^\/crew\/(\d+)$/);
+  if (req.method === 'GET' && req.url === '/crew') {
+    sendJson(res, 200, crew);
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/crew') {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const record = { id: nextId++, ...data };
+        crew.push(record);
+        sendJson(res, 200, record);
+      } catch {
+        sendJson(res, 400, { error: 'invalid json' });
+      }
+    });
+    return;
+  }
+  if (req.method === 'PUT' && idMatch) {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const id = Number(idMatch[1]);
+        const item = crew.find(c => c.id === id);
+        if (!item) {
+          sendJson(res, 404, { error: 'not found' });
+          return;
+        }
+        Object.assign(item, data);
+        sendJson(res, 200, item);
+      } catch {
+        sendJson(res, 400, { error: 'invalid json' });
+      }
+    });
+    return;
+  }
+  if (req.method === 'DELETE' && idMatch) {
+    const id = Number(idMatch[1]);
+    const idx = crew.findIndex(c => c.id === id);
+    if (idx === -1) {
+      sendJson(res, 404, { error: 'not found' });
+      return;
+    }
+    crew.splice(idx, 1);
+    sendJson(res, 200, { deleted: true });
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+}
+
 const server = http.createServer((req, res) => {
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('Postgres MCP server placeholder');
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Postgres MCP server placeholder');
+    return;
+  }
+
+  if (req.url.startsWith('/crew')) {
+    handleCrew(req, res);
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
 });
 
 server.listen(port, () => {

--- a/servers/telemetry/index.cjs
+++ b/servers/telemetry/index.cjs
@@ -20,6 +20,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (req.method === 'GET' && req.url === '/metrics') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(analytics.getMetrics()));
+    return;
+  }
+
   if (req.method === 'POST' && req.url === '/event') {
     let body = '';
     req.on('data', chunk => { body += chunk; });

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -11,9 +11,9 @@ function startServer(relativePath, port) {
   return spawn('node', [fullPath], { env });
 }
 
-function request(port) {
+function request(port, pathName = '/') {
   return new Promise((resolve, reject) => {
-    const req = http.request({ hostname: 'localhost', port, path: '/' }, (res) => {
+    const req = http.request({ hostname: 'localhost', port, path: pathName }, res => {
       let data = '';
       res.on('data', chunk => { data += chunk; });
       res.on('end', () => resolve(data));
@@ -23,23 +23,27 @@ function request(port) {
   });
 }
 
-function post(port, pathName, data) {
+function send(port, method, pathName, data) {
   return new Promise((resolve, reject) => {
     const req = http.request({
       hostname: 'localhost',
       port,
       path: pathName,
-      method: 'POST',
+      method,
       headers: { 'Content-Type': 'application/json' },
-    }, (res) => {
+    }, res => {
       let body = '';
       res.on('data', chunk => { body += chunk; });
       res.on('end', () => resolve({ statusCode: res.statusCode, body }));
     });
     req.on('error', reject);
-    req.write(JSON.stringify(data));
+    if (data) req.write(JSON.stringify(data));
     req.end();
   });
+}
+
+function post(port, pathName, data) {
+  return send(port, 'POST', pathName, data);
 }
 
 (async () => {
@@ -78,8 +82,27 @@ function post(port, pathName, data) {
   try {
     const gitResponse = await request(gitPort);
     assert.strictEqual(gitResponse, 'Git MCP server placeholder');
+    const gitInit = await request(gitPort, '/init');
+    assert.deepStrictEqual(JSON.parse(gitInit), { initialized: true });
+    const gitCommit = await request(gitPort, '/commit');
+    assert.deepStrictEqual(JSON.parse(gitCommit), { committed: true });
+    const gitStatus = await request(gitPort, '/status');
+    assert.deepStrictEqual(JSON.parse(gitStatus), { status: 'clean' });
     const pgResponse = await request(pgPort);
     assert.strictEqual(pgResponse, 'Postgres MCP server placeholder');
+    const created = await send(pgPort, 'POST', '/crew', { name: 'Alice', role: 'captain' });
+    const crewItem = JSON.parse(created.body);
+    assert.strictEqual(created.statusCode, 200);
+    const list1 = await request(pgPort, '/crew');
+    assert.deepStrictEqual(JSON.parse(list1), [crewItem]);
+    const updated = await send(pgPort, 'PUT', `/crew/${crewItem.id}`, { role: 'pilot' });
+    assert.strictEqual(updated.statusCode, 200);
+    const updatedItem = JSON.parse(updated.body);
+    assert.strictEqual(updatedItem.role, 'pilot');
+    const deleted = await send(pgPort, 'DELETE', `/crew/${crewItem.id}`);
+    assert.strictEqual(deleted.statusCode, 200);
+    const list2 = await request(pgPort, '/crew');
+    assert.deepStrictEqual(JSON.parse(list2), []);
     const telemetryResponse = await request(telemetryPort);
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
     const ksaResponse = await request(ksaPort);
@@ -111,6 +134,9 @@ function post(port, pathName, data) {
     assert.strictEqual(metrics2.eventCounts.test, 1);
     assert.strictEqual(metrics2.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics2.latestGeneration, 1);
+
+    const metricsResult = await request(telemetryPort, '/metrics');
+    assert.deepStrictEqual(JSON.parse(metricsResult), metrics2);
     console.log('Tests passed');
     git.kill();
     pg.kill();


### PR DESCRIPTION
## Summary
- implement `/init`, `/commit`, and `/status` routes for the git server
- create an in-memory CRUD API for crew on the postgres server
- expose `/metrics` on the telemetry server
- expand server tests for new behaviours

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880467abb30832696a6bbaa10bdd38f