### PR TITLE
Add JSON validation and tests

### DIFF
--- a/servers/aidirector/index.cjs
+++ b/servers/aidirector/index.cjs
@@ -1,4 +1,5 @@
 const http = require('http');
+const { logError, parseJson } = require('../utils.cjs');
 
 const port = process.env.PORT || 8100;
 
@@ -13,14 +14,14 @@ const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
-      try {
-        const data = JSON.parse(body || '{}');
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ received: data }));
-      } catch {
+      const data = parseJson(body);
+      if (!data) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('Invalid JSON');
+        return;
       }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ received: data }));
     });
     return;
   }
@@ -32,4 +33,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`AI Director server listening on port ${port}`);
 });
-server.on('error', err => console.error(err));
+server.on('error', logError);

--- a/servers/git/index.cjs
+++ b/servers/git/index.cjs
@@ -1,4 +1,5 @@
 const http = require('http');
+const { logError } = require('../utils.cjs');
 const port = process.env.PORT || 8080;
 
 function sendJson(res, obj) {
@@ -29,4 +30,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`Git MCP server listening on port ${port}`);
 });
-server.on('error', (err) => console.error(err));
+server.on('error', logError);

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,4 +1,5 @@
 const http = require('http');
+const { logError, parseJson } = require('../utils.cjs');
 
 const port = process.env.PORT || 8005;
 
@@ -15,17 +16,16 @@ const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
-      try {
-        const mcp = JSON.parse(body || '{}');
-        const ksaRequest = translateMcpToKsa(mcp);
-        const response = { requestId: ksaRequest.requestId, result: { received: ksaRequest } };
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(response));
-      } catch (err) {
-        console.error(err);
+      const mcp = parseJson(body);
+      if (!mcp) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('Invalid JSON');
+        return;
       }
+      const ksaRequest = translateMcpToKsa(mcp);
+      const response = { requestId: ksaRequest.requestId, result: { received: ksaRequest } };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(response));
     });
     return;
   }
@@ -36,4 +36,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`KSA MCP server listening on port ${port}`);
 });
-server.on('error', err => console.error(err));
+server.on('error', logError);

--- a/servers/postgres/index.cjs
+++ b/servers/postgres/index.cjs
@@ -1,4 +1,5 @@
 const http = require('http');
+const { logError, parseJson } = require('../utils.cjs');
 const port = process.env.PORT || 8003;
 
 const crew = [];
@@ -19,14 +20,14 @@ function handleCrew(req, res) {
     let body = '';
     req.on('data', c => { body += c; });
     req.on('end', () => {
-      try {
-        const data = JSON.parse(body || '{}');
-        const record = { id: nextId++, ...data };
-        crew.push(record);
-        sendJson(res, 200, record);
-      } catch {
+      const data = parseJson(body);
+      if (!data) {
         sendJson(res, 400, { error: 'invalid json' });
+        return;
       }
+      const record = { id: nextId++, ...data };
+      crew.push(record);
+      sendJson(res, 200, record);
     });
     return;
   }
@@ -34,19 +35,19 @@ function handleCrew(req, res) {
     let body = '';
     req.on('data', c => { body += c; });
     req.on('end', () => {
-      try {
-        const data = JSON.parse(body || '{}');
-        const id = Number(idMatch[1]);
-        const item = crew.find(c => c.id === id);
-        if (!item) {
-          sendJson(res, 404, { error: 'not found' });
-          return;
-        }
-        Object.assign(item, data);
-        sendJson(res, 200, item);
-      } catch {
+      const data = parseJson(body);
+      if (!data) {
         sendJson(res, 400, { error: 'invalid json' });
+        return;
       }
+      const id = Number(idMatch[1]);
+      const item = crew.find(c => c.id === id);
+      if (!item) {
+        sendJson(res, 404, { error: 'not found' });
+        return;
+      }
+      Object.assign(item, data);
+      sendJson(res, 200, item);
     });
     return;
   }
@@ -84,4 +85,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`Postgres MCP server listening on port ${port}`);
 });
-server.on('error', (err) => console.error(err));
+server.on('error', logError);

--- a/servers/telemetry/index.cjs
+++ b/servers/telemetry/index.cjs
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const analytics = require('./analytics.cjs');
+const { logError, parseJson } = require('../utils.cjs');
 
 const port = process.env.PORT || 8090;
 const logDir = path.join(__dirname, 'logs');
@@ -30,16 +31,15 @@ const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', () => {
-      try {
-        const event = JSON.parse(body || '{}');
-        logEvent(event);
-        res.writeHead(200, { 'Content-Type': 'text/plain' });
-        res.end('Event received');
-      } catch (e) {
-        console.error(e);
+      const event = parseJson(body);
+      if (!event) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('Invalid JSON');
+        return;
       }
+      logEvent(event);
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Event received');
     });
     return;
   }
@@ -51,4 +51,4 @@ const server = http.createServer((req, res) => {
 server.listen(port, () => {
   console.log(`Telemetry server listening on port ${port}`);
 });
-server.on('error', (err) => console.error(err));
+server.on('error', logError);

--- a/servers/utils.cjs
+++ b/servers/utils.cjs
@@ -1,0 +1,14 @@
+function logError(err) {
+  console.error(err);
+}
+
+function parseJson(body) {
+  try {
+    return JSON.parse(body || '{}');
+  } catch (err) {
+    logError(err);
+    return null;
+  }
+}
+
+module.exports = { logError, parseJson };

--- a/tests/aidirector.test.cjs
+++ b/tests/aidirector.test.cjs
@@ -17,8 +17,9 @@ function request(port, options = {}) {
       res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
     });
     req.on('error', reject);
-    if (options.method === 'POST' && options.body) {
-      req.write(JSON.stringify(options.body));
+    if (options.method === 'POST' && options.body !== undefined) {
+      if (typeof options.body === 'string') req.write(options.body);
+      else req.write(JSON.stringify(options.body));
     }
     req.end();
   });
@@ -41,6 +42,13 @@ function request(port, options = {}) {
     });
     assert.strictEqual(cmd.statusCode, 200);
     assert.deepStrictEqual(JSON.parse(cmd.body), { received: { action: 'test' } });
+    const bad = await request(port, {
+      method: 'POST',
+      path: '/command',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    });
+    assert.strictEqual(bad.statusCode, 400);
 
     console.log('AI Director tests passed');
   } finally {

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -37,7 +37,10 @@ function send(port, method, pathName, data) {
       res.on('end', () => resolve({ statusCode: res.statusCode, body }));
     });
     req.on('error', reject);
-    if (data) req.write(JSON.stringify(data));
+    if (data !== undefined) {
+      if (typeof data === 'string') req.write(data);
+      else req.write(JSON.stringify(data));
+    }
     req.end();
   });
 }
@@ -103,6 +106,10 @@ function post(port, pathName, data) {
     assert.strictEqual(deleted.statusCode, 200);
     const list2 = await request(pgPort, '/crew');
     assert.deepStrictEqual(JSON.parse(list2), []);
+    const badCreate = await send(pgPort, 'POST', '/crew', '{');
+    assert.strictEqual(badCreate.statusCode, 400);
+    const badUpdate = await send(pgPort, 'PUT', '/crew/1', '{');
+    assert.strictEqual(badUpdate.statusCode, 400);
     const telemetryResponse = await request(telemetryPort);
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
     const ksaResponse = await request(ksaPort);
@@ -112,8 +119,12 @@ function post(port, pathName, data) {
     assert.strictEqual(ksaResult.statusCode, 200);
     const expectedKsa = { command: 'notify_message', arguments: { message: 'hi', logType: 'Log' }, requestId: '42' };
     assert.deepStrictEqual(JSON.parse(ksaResult.body), { requestId: '42', result: { received: expectedKsa } });
+    const ksaBad = await post(ksaPort, '/', '{');
+    assert.strictEqual(ksaBad.statusCode, 400);
     const postResult = await post(telemetryPort, '/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
+    const badTelemetry = await post(telemetryPort, '/event', '{');
+    assert.strictEqual(badTelemetry.statusCode, 400);
 
     const genEvent = { type: 'generation_advanced', generation: 1 };
     const genResult = await post(telemetryPort, '/event', genEvent);


### PR DESCRIPTION
## Summary
- centralize logging and JSON parsing helpers
- validate request bodies across all servers
- respond with HTTP 400 when invalid JSON is sent
- cover invalid input cases in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688049de62ac8326b51826c7a0c94886