### PR TITLE
Add KSA engine forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prelint": "npm ci",
     "pretest": "npm ci",
     "test:godot": "if command -v dotnet >/dev/null 2>&1; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet not found, skipping Godot tests'; fi",
-    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
+    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
     "lint": "eslint servers tests"
   },
   "devDependencies": {

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,6 +1,8 @@
 const http = require('http');
 
 const port = process.env.PORT || 8005;
+const engineHost = process.env.KSA_ENGINE_HOST || 'localhost';
+const enginePort = process.env.KSA_ENGINE_PORT || 9000;
 
 function translateMcpToKsa(mcp) {
   return {
@@ -10,17 +12,42 @@ function translateMcpToKsa(mcp) {
   };
 }
 
+function forwardToEngine(ksaRequest) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: engineHost,
+      port: enginePort,
+      path: '/',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(ksaRequest));
+    req.end();
+  });
+}
+
 const server = http.createServer((req, res) => {
-  if (req.method === 'POST') {
+  if (req.method === 'POST' && req.url === '/') {
     let body = '';
     req.on('data', chunk => { body += chunk; });
-    req.on('end', () => {
+    req.on('end', async () => {
       try {
         const mcp = JSON.parse(body || '{}');
         const ksaRequest = translateMcpToKsa(mcp);
-        const response = { requestId: ksaRequest.requestId, result: { received: ksaRequest } };
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(response));
+        try {
+          const engineRes = await forwardToEngine(ksaRequest);
+          res.writeHead(engineRes.statusCode || 500, engineRes.headers);
+          res.end(engineRes.body);
+        } catch (err) {
+          console.error(err);
+          res.writeHead(502, { 'Content-Type': 'text/plain' });
+          res.end('Failed to reach KSA engine');
+        }
       } catch (err) {
         console.error(err);
         res.writeHead(400, { 'Content-Type': 'text/plain' });
@@ -29,8 +56,13 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('KSA MCP server placeholder');
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('KSA MCP server placeholder');
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
 });
 
 server.listen(port, () => {

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -1,0 +1,66 @@
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+const assert = require('assert');
+
+function startServer(relativePath, port, extraEnv = {}) {
+  const fullPath = path.join(__dirname, '..', relativePath);
+  const env = { ...process.env, PORT: String(port), ...extraEnv };
+  return spawn('node', [fullPath], { env });
+}
+
+function post(port, data) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: 'localhost',
+      port,
+      path: '/',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(data));
+    req.end();
+  });
+}
+
+(async () => {
+  const enginePort = 9010;
+  const adapterPort = 9011;
+  const received = [];
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      received.push(JSON.parse(body || '{}'));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise(r => engine.listen(enginePort, r));
+  const adapter = startServer('servers/ksa/index.cjs', adapterPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(enginePort)
+  });
+  try {
+    await new Promise(r => setTimeout(r, 100));
+    const mcp = { method: 'notify_message', params: { msg: 'hello' }, id: '99' };
+    const result = await post(adapterPort, mcp);
+    assert.strictEqual(result.statusCode, 200);
+    assert.deepStrictEqual(JSON.parse(result.body), { ok: true });
+    assert.deepStrictEqual(received[0], {
+      command: 'notify_message',
+      arguments: { msg: 'hello' },
+      requestId: '99'
+    });
+    console.log('KSA adapter tests passed');
+  } finally {
+    adapter.kill();
+    engine.close();
+  }
+})();
+

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -5,9 +5,9 @@ const fs = require('fs');
 const assert = require('assert');
 const analytics = require('../servers/telemetry/analytics.cjs');
 
-function startServer(relativePath, port) {
+function startServer(relativePath, port, extraEnv = {}) {
   const fullPath = path.join(__dirname, '..', relativePath);
-  const env = { ...process.env, PORT: String(port) };
+  const env = { ...process.env, PORT: String(port), ...extraEnv };
   return spawn('node', [fullPath], { env });
 }
 
@@ -51,10 +51,23 @@ function post(port, pathName, data) {
   const pgPort = 8004;
   const telemetryPort = 8091;
   const ksaPort = 8006;
+  const ksaEnginePort = 8007;
+  const ksaEngine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+    });
+  });
+  await new Promise(r => ksaEngine.listen(ksaEnginePort, r));
   const git = startServer('servers/git/index.cjs', gitPort);
   const pg = startServer('servers/postgres/index.cjs', pgPort);
   const telemetry = startServer('servers/telemetry/index.cjs', telemetryPort);
-  const ksa = startServer('servers/ksa/index.cjs', ksaPort);
+  const ksa = startServer('servers/ksa/index.cjs', ksaPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(ksaEnginePort)
+  });
   const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
   if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
   async function waitForServer(port, timeout = 5000) {
@@ -111,7 +124,7 @@ function post(port, pathName, data) {
     const ksaResult = await post(ksaPort, '/', mcpCmd);
     assert.strictEqual(ksaResult.statusCode, 200);
     const expectedKsa = { command: 'notify_message', arguments: { message: 'hi', logType: 'Log' }, requestId: '42' };
-    assert.deepStrictEqual(JSON.parse(ksaResult.body), { requestId: '42', result: { received: expectedKsa } });
+    assert.deepStrictEqual(JSON.parse(ksaResult.body), expectedKsa);
     const postResult = await post(telemetryPort, '/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
 
@@ -142,11 +155,13 @@ function post(port, pathName, data) {
     pg.kill();
     telemetry.kill();
     ksa.kill();
+    ksaEngine.close();
   } catch (err) {
     git.kill();
     pg.kill();
     telemetry.kill();
     ksa.kill();
+    ksaEngine.close();
     console.error(err);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- forward MCP requests from the KSA adapter to a configurable engine endpoint
- propagate engine responses or return an error
- test translation and forwarding behaviour in new `ksa-adapter.test.cjs`
- update server integration tests to use a mock engine
- run new test from npm script

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688049dc6ec483268eae2c95c6b59968