### PR TITLE
Add GoDotTest coverage

### DIFF
--- a/Godot.Tests/Godot.Tests.csproj
+++ b/Godot.Tests/Godot.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Godot.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace>Godot.Tests</RootNamespace>
@@ -11,5 +12,16 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Godot/TBDSpaceRPG.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../src/OrbitalMechanics/OrbitPlanner.cs" />
+    <Compile Include="test/stubs/CelestialBody.cs" />
+    <Compile Include="../src/OrbitalMechanics/OrbitData.cs" />
+    <Compile Include="../src/OrbitalMechanics/Vector3d.cs" />
+    <Compile Include="../src/SimpleKeplerOrbits/*.cs" />
+    <Compile Include="../src/ShipCustomization/ShipCustomizationManager.cs" />
+    <Compile Include="../src/ShipCustomization/SpaceshipMovement.cs" />
+    <Compile Include="test/Tests.cs" />
+    <Compile Include="test/src/*.cs" />
   </ItemGroup>
 </Project>

--- a/Godot.Tests/test/src/OrbitPlannerTests.cs
+++ b/Godot.Tests/test/src/OrbitPlannerTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+using OrbitalMechanics;
+using SimpleKeplerOrbits;
+
+public class OrbitPlannerTests : TestClass {
+    public OrbitPlannerTests(Node scene) : base(scene) { }
+
+    [Test]
+    public void PlanTransfer_ComputesAverageSemiMajorAxis() {
+        var origin = new CelestialBody();
+        var dest = new CelestialBody();
+
+        typeof(CelestialBody).GetField("initialOrbit", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(origin, new OrbitData { orbit = new KeplerOrbit { semiMajorAxis = 10, gravitationalParameter = 1 } });
+        typeof(CelestialBody).GetField("initialOrbit", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(dest, new OrbitData { orbit = new KeplerOrbit { semiMajorAxis = 20, gravitationalParameter = 1 } });
+
+        var planner = new OrbitPlanner();
+        var result = planner.PlanTransfer(origin, dest);
+
+        result.ShouldNotBeNull();
+        result.orbit.semiMajorAxis.ShouldBe(15);
+    }
+}

--- a/Godot.Tests/test/src/ShipCustomizationManagerTests.cs
+++ b/Godot.Tests/test/src/ShipCustomizationManagerTests.cs
@@ -1,0 +1,26 @@
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public class ShipCustomizationManagerTests : TestClass {
+    public ShipCustomizationManagerTests(Node scene) : base(scene) { }
+
+    [Test]
+    public void UpgradeThrust_IncreasesLevelAndAppliesToMovement() {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeThrust();
+        manager.ThrustLevel.ShouldBe(2);
+        movement.ThrustForce.ShouldBe(20f);
+    }
+
+    [Test]
+    public void ResetUpgrades_SetsLevelsToOne() {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeSpeed();
+        manager.ResetUpgrades();
+        manager.SpeedLevel.ShouldBe(1);
+        movement.MaxSpeed.ShouldBe(20f);
+    }
+}

--- a/Godot.Tests/test/stubs/CelestialBody.cs
+++ b/Godot.Tests/test/stubs/CelestialBody.cs
@@ -1,0 +1,6 @@
+namespace OrbitalMechanics {
+    public class CelestialBody {
+        private OrbitData initialOrbit = new OrbitData();
+        public OrbitData InitialOrbit => initialOrbit;
+    }
+}


### PR DESCRIPTION
## Summary
- add OrbitPlanner and ShipCustomizationManager tests in Godot.Tests
- provide a stub CelestialBody for the tests
- configure Godot.Tests project compile items
- fix CelestialBody stub so reflection in tests works

## Testing
- `npm run lint`
- `dotnet build Godot.Tests/Godot.Tests.csproj`
- `./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish`

------
https://chatgpt.com/codex/tasks/task_e_688049ddc5cc8326bd077811eaa8dba6