### PR TITLE
Fix KSA adapter response flow

### DIFF
--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,5 +1,5 @@
 const http = require('http');
-const { logError, parseJson } = require('../utils.cjs');
+const { logError } = require('../utils.cjs');
 
 const port = process.env.PORT || 8005;
 const engineHost = process.env.KSA_ENGINE_HOST || 'localhost';
@@ -56,10 +56,6 @@ const server = http.createServer((req, res) => {
         res.end('Invalid JSON');
         return;
       }
-      const ksaRequest = translateMcpToKsa(mcp);
-      const response = { requestId: ksaRequest.requestId, result: { received: ksaRequest } };
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(response));
     });
     return;
   }


### PR DESCRIPTION
## Summary
- stop redeclaring `ksaRequest`
- forward engine responses directly

## Testing
- `npm run lint`
- `node tests/ksa-adapter.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6880d4433d208326872c2c04c2e9012e