### PR TITLE
Add core MCP server module and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
     "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
 
-    "lint": "eslint servers tests"
+    "lint": "eslint servers tests",
+    "start:core-mcp": "node servers/core-mcp/index.cjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/servers/core-mcp/index.cjs
+++ b/servers/core-mcp/index.cjs
@@ -1,0 +1,161 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const analytics = require('../telemetry/analytics.cjs');
+const { parseJson, logError } = require('../utils.cjs');
+
+const port = process.env.PORT || 8100;
+
+// --- Git state ---
+
+function handleGit(req, res, subUrl) {
+  if (req.method === 'GET' && subUrl === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Git MCP server placeholder');
+    return true;
+  }
+  if (req.method === 'GET' && subUrl === '/init') {
+    sendJson(res, 200, { initialized: true });
+    return true;
+  }
+  if (req.method === 'GET' && subUrl === '/commit') {
+    sendJson(res, 200, { committed: true });
+    return true;
+  }
+  if (req.method === 'GET' && subUrl === '/status') {
+    sendJson(res, 200, { status: 'clean' });
+    return true;
+  }
+  return false;
+}
+
+// --- Postgres state ---
+
+const crew = [];
+let nextId = 1;
+
+function sendJson(res, code, obj) {
+  res.writeHead(code, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+function handleCrew(req, res, subUrl) {
+  const idMatch = subUrl.match(/^\/crew\/(\d+)$/);
+  if (req.method === 'GET' && subUrl === '/crew') {
+    sendJson(res, 200, crew);
+    return true;
+  }
+  if (req.method === 'POST' && subUrl === '/crew') {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      const data = parseJson(body);
+      if (!data) return sendJson(res, 400, { error: 'invalid json' });
+      const record = { id: nextId++, ...data };
+      crew.push(record);
+      sendJson(res, 200, record);
+    });
+    return true;
+  }
+  if (req.method === 'PUT' && idMatch) {
+    let body = '';
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      const data = parseJson(body);
+      if (!data) return sendJson(res, 400, { error: 'invalid json' });
+      const id = Number(idMatch[1]);
+      const item = crew.find(c => c.id === id);
+      if (!item) return sendJson(res, 404, { error: 'not found' });
+      Object.assign(item, data);
+      sendJson(res, 200, item);
+    });
+    return true;
+  }
+  if (req.method === 'DELETE' && idMatch) {
+    const id = Number(idMatch[1]);
+    const idx = crew.findIndex(c => c.id === id);
+    if (idx === -1) return sendJson(res, 404, { error: 'not found' });
+    crew.splice(idx, 1);
+    sendJson(res, 200, { deleted: true });
+    return true;
+  }
+  return false;
+}
+
+function handlePostgres(req, res, subUrl) {
+  if (req.method === 'GET' && subUrl === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Postgres MCP server placeholder');
+    return true;
+  }
+  if (subUrl.startsWith('/crew')) {
+    return handleCrew(req, res, subUrl);
+  }
+  return false;
+}
+
+// --- Telemetry state ---
+
+const logDir = path.join(__dirname, '..', 'telemetry', 'logs');
+fs.mkdirSync(logDir, { recursive: true });
+const logFile = path.join(logDir, 'events.log');
+
+function logEvent(event) {
+  fs.appendFileSync(logFile, `${JSON.stringify(event)}\n`);
+  analytics.computeMetrics(event);
+}
+
+function handleTelemetry(req, res, subUrl) {
+  if (req.method === 'GET' && subUrl === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Telemetry server placeholder');
+    return true;
+  }
+  if (req.method === 'GET' && subUrl === '/metrics') {
+    sendJson(res, 200, analytics.getMetrics());
+    return true;
+  }
+  if (req.method === 'POST' && subUrl === '/event') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      const event = parseJson(body);
+      if (!event) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Invalid JSON');
+        return;
+      }
+      logEvent(event);
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Event received');
+    });
+    return true;
+  }
+  return false;
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    if (req.url.startsWith('/git')) {
+      const sub = req.url.substring(4) || '/';
+      if (handleGit(req, res, sub)) return;
+    } else if (req.url.startsWith('/postgres')) {
+      const sub = req.url.substring(9) || '/';
+      if (handlePostgres(req, res, sub)) return;
+    } else if (req.url.startsWith('/telemetry')) {
+      const sub = req.url.substring(10) || '/';
+      if (handleTelemetry(req, res, sub)) return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  } catch (err) {
+    logError(err);
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Server error');
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Core MCP server listening on port ${port}`);
+});
+server.on('error', logError);

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -50,9 +50,7 @@ function post(port, pathName, data) {
 }
 
 (async () => {
-  const gitPort = 8081;
-  const pgPort = 8004;
-  const telemetryPort = 8091;
+  const corePort = 8095;
   const ksaPort = 8006;
   const ksaEnginePort = 8007;
   const ksaEngine = http.createServer((req, res) => {
@@ -64,9 +62,7 @@ function post(port, pathName, data) {
     });
   });
   await new Promise(r => ksaEngine.listen(ksaEnginePort, r));
-  const git = startServer('servers/git/index.cjs', gitPort);
-  const pg = startServer('servers/postgres/index.cjs', pgPort);
-  const telemetry = startServer('servers/telemetry/index.cjs', telemetryPort);
+  const core = startServer('servers/core-mcp/index.cjs', corePort);
   const ksa = startServer('servers/ksa/index.cjs', ksaPort, {
     KSA_ENGINE_HOST: 'localhost',
     KSA_ENGINE_PORT: String(ksaEnginePort)
@@ -90,40 +86,38 @@ function post(port, pathName, data) {
   }
 
   await Promise.all([
-    waitForServer(gitPort),
-    waitForServer(pgPort),
-    waitForServer(telemetryPort),
+    waitForServer(corePort),
     waitForServer(ksaPort),
   ]);
   try {
-    const gitResponse = await request(gitPort);
+    const gitResponse = await request(corePort, '/git');
     assert.strictEqual(gitResponse, 'Git MCP server placeholder');
-    const gitInit = await request(gitPort, '/init');
+    const gitInit = await request(corePort, '/git/init');
     assert.deepStrictEqual(JSON.parse(gitInit), { initialized: true });
-    const gitCommit = await request(gitPort, '/commit');
+    const gitCommit = await request(corePort, '/git/commit');
     assert.deepStrictEqual(JSON.parse(gitCommit), { committed: true });
-    const gitStatus = await request(gitPort, '/status');
+    const gitStatus = await request(corePort, '/git/status');
     assert.deepStrictEqual(JSON.parse(gitStatus), { status: 'clean' });
-    const pgResponse = await request(pgPort);
+    const pgResponse = await request(corePort, '/postgres');
     assert.strictEqual(pgResponse, 'Postgres MCP server placeholder');
-    const created = await send(pgPort, 'POST', '/crew', { name: 'Alice', role: 'captain' });
+    const created = await send(corePort, 'POST', '/postgres/crew', { name: 'Alice', role: 'captain' });
     const crewItem = JSON.parse(created.body);
     assert.strictEqual(created.statusCode, 200);
-    const list1 = await request(pgPort, '/crew');
+    const list1 = await request(corePort, '/postgres/crew');
     assert.deepStrictEqual(JSON.parse(list1), [crewItem]);
-    const updated = await send(pgPort, 'PUT', `/crew/${crewItem.id}`, { role: 'pilot' });
+    const updated = await send(corePort, 'PUT', `/postgres/crew/${crewItem.id}`, { role: 'pilot' });
     assert.strictEqual(updated.statusCode, 200);
     const updatedItem = JSON.parse(updated.body);
     assert.strictEqual(updatedItem.role, 'pilot');
-    const deleted = await send(pgPort, 'DELETE', `/crew/${crewItem.id}`);
+    const deleted = await send(corePort, 'DELETE', `/postgres/crew/${crewItem.id}`);
     assert.strictEqual(deleted.statusCode, 200);
-    const list2 = await request(pgPort, '/crew');
+    const list2 = await request(corePort, '/postgres/crew');
     assert.deepStrictEqual(JSON.parse(list2), []);
-    const badCreate = await send(pgPort, 'POST', '/crew', '{');
+    const badCreate = await send(corePort, 'POST', '/postgres/crew', '{');
     assert.strictEqual(badCreate.statusCode, 400);
-    const badUpdate = await send(pgPort, 'PUT', '/crew/1', '{');
+    const badUpdate = await send(corePort, 'PUT', '/postgres/crew/1', '{');
     assert.strictEqual(badUpdate.statusCode, 400);
-    const telemetryResponse = await request(telemetryPort);
+    const telemetryResponse = await request(corePort, '/telemetry');
     assert.strictEqual(telemetryResponse, 'Telemetry server placeholder');
     const ksaResponse = await request(ksaPort);
     assert.strictEqual(ksaResponse, 'KSA MCP server placeholder');
@@ -133,13 +127,13 @@ function post(port, pathName, data) {
     const expectedKsa = { command: 'notify_message', arguments: { message: 'hi', logType: 'Log' }, requestId: '42' };
     assert.deepStrictEqual(JSON.parse(ksaResult.body), expectedKsa);
 
-    const postResult = await post(telemetryPort, '/event', { type: 'test' });
+    const postResult = await post(corePort, '/telemetry/event', { type: 'test' });
     assert.strictEqual(postResult.statusCode, 200);
-    const badTelemetry = await post(telemetryPort, '/event', '{');
+    const badTelemetry = await post(corePort, '/telemetry/event', '{');
     assert.strictEqual(badTelemetry.statusCode, 400);
 
     const genEvent = { type: 'generation_advanced', generation: 1 };
-    const genResult = await post(telemetryPort, '/event', genEvent);
+    const genResult = await post(corePort, '/telemetry/event', genEvent);
     assert.strictEqual(genResult.statusCode, 200);
     await new Promise(r => setTimeout(r, 100));
     const logPath = path.join(__dirname, '..', 'servers', 'telemetry', 'logs', 'events.log');
@@ -158,18 +152,14 @@ function post(port, pathName, data) {
     assert.strictEqual(metrics2.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics2.latestGeneration, 1);
 
-    const metricsResult = await request(telemetryPort, '/metrics');
+    const metricsResult = await request(corePort, '/telemetry/metrics');
     assert.deepStrictEqual(JSON.parse(metricsResult), metrics2);
     console.log('Tests passed');
-    git.kill();
-    pg.kill();
-    telemetry.kill();
+    core.kill();
     ksa.kill();
     ksaEngine.close();
   } catch (err) {
-    git.kill();
-    pg.kill();
-    telemetry.kill();
+    core.kill();
     ksa.kill();
     ksaEngine.close();
     console.error(err);


### PR DESCRIPTION
## Summary
- add `servers/core-mcp` server combining Git, Postgres and Telemetry routes
- expose a `start:core-mcp` script in `package.json`
- update `tests/server.test.cjs` to use the unified server

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880dd4986a8832696154c4552c45e23