### PR TITLE
Add command handlers for Godot server

### DIFF
--- a/servers/godot.Tests/WebSocketTests.cs
+++ b/servers/godot.Tests/WebSocketTests.cs
@@ -35,13 +35,13 @@ public class WebSocketTests
     }
 
     [Test]
-    public async Task RequestRespondsWithOk()
+    public async Task ExecuteMenuItemRespondsWithExecuted()
     {
         using var ws = new ClientWebSocket();
         var uri = new Uri($"ws://localhost:{_port}/");
         await ws.ConnectAsync(uri, CancellationToken.None);
 
-        var reqJson = "{\"type\":\"test\",\"id\":\"42\",\"parameters\":{}}";
+        var reqJson = "{\"type\":\"execute_menu_item\",\"id\":\"42\",\"parameters\":{\"item\":\"open\"}}";
         var bytes = Encoding.UTF8.GetBytes(reqJson);
         await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
 
@@ -50,7 +50,7 @@ public class WebSocketTests
         var resp = Encoding.UTF8.GetString(buffer, 0, result.Count);
         var doc = JsonDocument.Parse(resp);
         Assert.That(doc.RootElement.GetProperty("id").GetString(), Is.EqualTo("42"));
-        Assert.That(doc.RootElement.GetProperty("result").GetProperty("status").GetString(), Is.EqualTo("ok"));
+        Assert.That(doc.RootElement.GetProperty("result").GetProperty("executed").GetString(), Is.EqualTo("open"));
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class WebSocketTests
 
         Assert.That(ws.State, Is.EqualTo(WebSocketState.Open));
 
-        var reqJson = "{\"type\":\"test\",\"id\":\"99\",\"parameters\":{}}";
+        var reqJson = "{\"type\":\"execute_menu_item\",\"id\":\"99\",\"parameters\":{}}";
         var reqBytes = Encoding.UTF8.GetBytes(reqJson);
         await ws.SendAsync(reqBytes, WebSocketMessageType.Text, true, CancellationToken.None);
 
@@ -75,7 +75,27 @@ public class WebSocketTests
         var resp = Encoding.UTF8.GetString(buffer, 0, result.Count);
         var doc = JsonDocument.Parse(resp);
         Assert.That(doc.RootElement.GetProperty("id").GetString(), Is.EqualTo("99"));
-        Assert.That(doc.RootElement.GetProperty("result").GetProperty("status").GetString(), Is.EqualTo("ok"));
+        Assert.That(doc.RootElement.GetProperty("result").GetProperty("executed").GetString(), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public async Task NotifyMessageStoresMessage()
+    {
+        using var ws = new ClientWebSocket();
+        var uri = new Uri($"ws://localhost:{_port}/");
+        await ws.ConnectAsync(uri, CancellationToken.None);
+
+        var reqJson = "{\"type\":\"notify_message\",\"id\":\"55\",\"parameters\":{\"message\":\"hello\"}}";
+        var bytes = Encoding.UTF8.GetBytes(reqJson);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+
+        var buffer = new byte[1024];
+        var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+        var resp = Encoding.UTF8.GetString(buffer, 0, result.Count);
+        var doc = JsonDocument.Parse(resp);
+        Assert.That(doc.RootElement.GetProperty("id").GetString(), Is.EqualTo("55"));
+        Assert.That(doc.RootElement.GetProperty("result").GetProperty("notified").GetBoolean(), Is.True);
+        Assert.That(NotifyMessageHandler.LastMessage, Is.EqualTo("hello"));
     }
 
     [Test]

--- a/servers/godot/Program.cs
+++ b/servers/godot/Program.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,31 @@ public class McpRequest
     public string type { get; set; } = string.Empty;
     public string id { get; set; } = string.Empty;
     public JsonElement parameters { get; set; }
+}
+
+public interface IMcpCommandHandler
+{
+    Task<object> HandleAsync(JsonElement parameters);
+}
+
+public class ExecuteMenuItemHandler : IMcpCommandHandler
+{
+    public Task<object> HandleAsync(JsonElement parameters)
+    {
+        var item = parameters.TryGetProperty("item", out var itemProp) ? itemProp.GetString() : string.Empty;
+        return Task.FromResult<object>(new { executed = item });
+    }
+}
+
+public class NotifyMessageHandler : IMcpCommandHandler
+{
+    public static string LastMessage = string.Empty;
+
+    public Task<object> HandleAsync(JsonElement parameters)
+    {
+        LastMessage = parameters.TryGetProperty("message", out var msgProp) ? msgProp.GetString() ?? string.Empty : string.Empty;
+        return Task.FromResult<object>(new { notified = true });
+    }
 }
 
 public class McpResponse
@@ -26,14 +52,20 @@ public class SimpleWebSocketServer : IDisposable
     private readonly HttpListener _listener;
     private readonly CancellationTokenSource _cts = new();
     private Task? _listenTask;
+    private readonly IDictionary<string, IMcpCommandHandler> _handlers;
 
     public int Port { get; }
 
-    public SimpleWebSocketServer(int port)
+    public SimpleWebSocketServer(int port, IDictionary<string, IMcpCommandHandler>? handlers = null)
     {
         Port = port;
         _listener = new HttpListener();
         _listener.Prefixes.Add($"http://+:{port}/");
+        _handlers = handlers ?? new Dictionary<string, IMcpCommandHandler>
+        {
+            ["execute_menu_item"] = new ExecuteMenuItemHandler(),
+            ["notify_message"] = new NotifyMessageHandler()
+        };
     }
 
     public void Start()
@@ -95,7 +127,13 @@ public class SimpleWebSocketServer : IDisposable
                 var request = JsonSerializer.Deserialize<McpRequest>(json);
                 if (request != null)
                 {
-                    var response = new McpResponse { id = request.id };
+                    object resultObj = new { status = "unknown_command" };
+                    if (_handlers.TryGetValue(request.type, out var handler))
+                    {
+                        resultObj = await handler.HandleAsync(request.parameters);
+                    }
+
+                    var response = new McpResponse { id = request.id, result = resultObj };
                     var respJson = JsonSerializer.Serialize(response);
                     var respBytes = Encoding.UTF8.GetBytes(respJson);
                     await socket.SendAsync(respBytes, WebSocketMessageType.Text, true, token);


### PR DESCRIPTION
## Summary
- add a command handler interface and two handlers
- route requests in `SimpleWebSocketServer` based on `McpRequest.type`
- update WebSocket tests for new handlers

## Testing
- `npm run lint`
- `npm test`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6880dd4af6248326a9ef94c57144238c