### PR TITLE
Add lint docs and dotnet formatting checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 18
       - run: dotnet format --verify-no-changes csharp/OrbitalMechanics.sln
+      - run: dotnet format --verify-no-changes Godot/TBDSpaceRPG.csproj
       - run: npm ci
       - run: npm run lint
       - run: npm ci

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -250,6 +250,27 @@ pwsh -File tests/test-servers.ps1
 
 For installation instructions, see the [PowerShell installation guide](https://learn.microsoft.com/powershell/scripting/install/installing-powershell).
 
+## Linting
+
+Run the linters to ensure consistent code style for both the C# and Node.js projects.
+
+### .NET Formatting
+
+Use `dotnet format` to verify that the C# projects follow the repository's style guidelines:
+
+```sh
+dotnet format Godot/TBDSpaceRPG.csproj
+dotnet format csharp/OrbitalMechanics.sln
+```
+
+### ESLint
+
+The Node.js servers use ESLint for static analysis. Install dependencies and run:
+
+```sh
+npm run lint
+```
+
 ## Ship Customization System
 
 The Ship Customization System (implemented according to Section 4.16 of the technical documentation) consists of:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,4 +13,11 @@ export default [
     rules: {
     },
   },
+  {
+    files: ["servers/**/*.cjs"],
+    rules: {
+      "no-console": "off",
+      "no-unused-vars": "warn",
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- run `dotnet format` on Godot project in CI
- configure server-specific ESLint rules
- document lint commands

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6880e2a11170832697a60d08fc514fa4