### PR TITLE
Add glTF export script and CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,19 @@ jobs:
         with:
           name: Unity Test Results
           path: ${{ steps.tests.outputs.artifactsPath }}
+
+  export-assets:
+    runs-on: ubuntu-latest
+    needs: unity-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run glTF export
+        shell: pwsh
+        run: ./export-gltf.ps1
+      - name: Archive glTF Assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: glTF Assets
+          path: |
+            Assets_glTF
+            Godot/Assets_glTF

--- a/export-gltf.ps1
+++ b/export-gltf.ps1
@@ -1,0 +1,19 @@
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$unityCmd = Get-Command unity-editor -ErrorAction SilentlyContinue
+$projectPath = Join-Path $repoRoot 'TBD SpaceGame/TBD SpaceGame'
+if ($unityCmd) {
+    Write-Host "Running Unity glTF exporter..."
+    & $unityCmd.Source -batchmode -nographics -quit -projectPath $projectPath -executeMethod Exporters.ExportGLTF
+} else {
+    Write-Warning "unity-editor not found. Skipping glTF export."
+}
+
+$destRoot = Join-Path $repoRoot 'Assets_glTF'
+$godotDest = Join-Path $repoRoot 'Godot/Assets_glTF'
+New-Item -ItemType Directory -Force -Path $destRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $godotDest | Out-Null
+
+Get-ChildItem $projectPath -Recurse -Include *.gltf,*.glb,*.png,*.jpg -ErrorAction SilentlyContinue | ForEach-Object {
+    Copy-Item $_.FullName -Destination $destRoot -Force
+    Copy-Item $_.FullName -Destination $godotDest -Force
+}


### PR DESCRIPTION
## Summary
- add PowerShell script `export-gltf.ps1` to run Unity's glTF exporter if available
- archive exported glTF files in CI via new `export-assets` job

## Testing
- `npm run lint`
- `npm test`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6880e29f3fcc8326a952bce71c466a90