### PR TITLE
Add tests for StationDock and upgrade methods

### DIFF
--- a/Godot.Tests/test/src/ShipCustomizationManagerTests.cs
+++ b/Godot.Tests/test/src/ShipCustomizationManagerTests.cs
@@ -23,4 +23,31 @@ public class ShipCustomizationManagerTests : TestClass {
         manager.SpeedLevel.ShouldBe(1);
         movement.MaxSpeed.ShouldBe(20f);
     }
+
+    [Test]
+    public void UpgradeSpeed_IncreasesLevelAndAppliesToMovement() {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeSpeed();
+        manager.SpeedLevel.ShouldBe(2);
+        movement.MaxSpeed.ShouldBe(40f);
+    }
+
+    [Test]
+    public void UpgradeRotation_IncreasesLevelAndAppliesToMovement() {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeRotation();
+        manager.RotationLevel.ShouldBe(2);
+        movement.RotationSpeed.ShouldBe(180f);
+    }
+
+    [Test]
+    public void UpgradeBraking_IncreasesLevelAndAppliesToMovement() {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeBraking();
+        manager.BrakingLevel.ShouldBe(2);
+        movement.BrakingForce.ShouldBe(10f);
+    }
 }

--- a/Godot.Tests/test/src/StationDockPersistenceTests.cs
+++ b/Godot.Tests/test/src/StationDockPersistenceTests.cs
@@ -10,15 +10,57 @@ public class StationDockPersistenceTests : TestClass
     [Test]
     public void SaveAndLoadUpgradeLevel()
     {
-        var dock = new StationDock();
-        dock.SaveFile = "test_game_state.json";
-        dock.UpgradeFile = "test_upgrades.json";
-        dock.UpgradeLevel = 5;
-        dock.SaveUpgrade();
-        dock.UpgradeLevel = 0;
-        dock.LoadUpgrade();
-        dock.UpgradeLevel.ShouldBe(5);
-        File.Delete("test_upgrades.json");
-        File.Delete("test_game_state.json");
+        var gamePath = Path.GetTempFileName();
+        var upgradePath = Path.GetTempFileName();
+
+        try {
+            var dock = new StationDock();
+            dock.SaveFile = gamePath;
+            dock.UpgradeFile = upgradePath;
+            dock.UpgradeLevel = 5;
+            dock.SaveUpgrade();
+            dock.UpgradeLevel = 0;
+            dock.LoadUpgrade();
+            dock.UpgradeLevel.ShouldBe(5);
+        }
+        finally {
+            if (File.Exists(upgradePath)) File.Delete(upgradePath);
+            if (File.Exists(gamePath)) File.Delete(gamePath);
+        }
+    }
+
+    [Test]
+    public void SaveState_WritesGameAndUpgradeFiles()
+    {
+        var gamePath = Path.GetTempFileName();
+        var upgradePath = Path.GetTempFileName();
+
+        try {
+            var dock = new StationDock();
+            dock.SaveFile = gamePath;
+            dock.UpgradeFile = upgradePath;
+            dock.UpgradeLevel = 2;
+            dock.ShipPosition = new Vector3(1, 2, 3);
+            dock.CrewStats = new CrewStats { crewCount = 4, morale = 7 };
+
+            typeof(StationDock)
+                .GetMethod("SaveState", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                .Invoke(dock, null);
+
+            var state = GameState.Load(gamePath);
+            state.upgradeLevel.ShouldBe(2);
+            state.shipPosition.X.ShouldBe(1);
+            state.shipPosition.Y.ShouldBe(2);
+            state.shipPosition.Z.ShouldBe(3);
+            state.crewStats.crewCount.ShouldBe(4);
+            state.crewStats.morale.ShouldBe(7);
+
+            var upgradeJson = File.ReadAllText(upgradePath);
+            upgradeJson.ShouldContain("\"upgradeLevel\":2");
+        }
+        finally {
+            if (File.Exists(upgradePath)) File.Delete(upgradePath);
+            if (File.Exists(gamePath)) File.Delete(gamePath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add tests for StationDock.SaveState ensuring save files are written
- cover UpgradeSpeed, UpgradeRotation, and UpgradeBraking in ShipCustomizationManagerTests
- clean up temp files with try/finally in StationDockPersistenceTests

## Testing
- `npm run lint`
- `npm run test:godot`

------
https://chatgpt.com/codex/tasks/task_e_6880e2a0caac8326b85619363f3709f5