### PR TITLE
Add timeout and deterministic ports for KSA adapter tests

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -93,15 +93,20 @@ Routes requests to appropriate MCP servers.
 
 ### KSA Adapter
 
-Placeholder adapter for the upcoming KSA engine. It simply echoes MCP requests.
+The KSA adapter forwards MCP commands to a running KSA engine instance. By
+default it looks for an engine on `localhost:9000`, but you can configure a
+custom endpoint using environment variables:
+
+- `KSA_ENGINE_HOST` and `KSA_ENGINE_PORT` – specify the host and port
+- `KSA_ENGINE_ENDPOINT` – full URL including path (overrides host/port)
 
 ```powershell
-# Start the KSA adapter
+# Forward MCP commands to http://my-engine.local:9100/engine
+$env:KSA_ENGINE_ENDPOINT = 'http://my-engine.local:9100/engine'
 ./run-ksa-server.ps1
 ```
 
-When the real engine API is available, replace the placeholder server with the
-actual implementation and update configuration values accordingly.
+The adapter returns the engine's raw HTTP response to the caller.
 
 ### All Servers
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prelint": "npm ci",
     "pretest": "npm ci",
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
-    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
+    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
 
     "lint": "eslint servers tests",
     "start:core-mcp": "node servers/core-mcp/index.cjs"

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,9 +1,19 @@
 const http = require('http');
+const https = require('https');
 const { logError } = require('../utils.cjs');
 
 const port = process.env.PORT || 8005;
 const engineHost = process.env.KSA_ENGINE_HOST || 'localhost';
 const enginePort = process.env.KSA_ENGINE_PORT || 9000;
+const engineEndpoint = process.env.KSA_ENGINE_ENDPOINT;
+
+let engineUrl;
+try {
+  engineUrl = new URL(engineEndpoint || `http://${engineHost}:${enginePort}/`);
+} catch (err) {
+  console.warn('Invalid KSA_ENGINE_ENDPOINT:', err);
+  engineUrl = new URL(`http://${engineHost}:${enginePort}/`);
+}
 
 function translateMcpToKsa(mcp) {
   return {
@@ -15,16 +25,17 @@ function translateMcpToKsa(mcp) {
 
 function forwardToEngine(ksaRequest) {
   return new Promise((resolve, reject) => {
-    const req = http.request({
-      hostname: engineHost,
-      port: enginePort,
-      path: '/',
+    const httpModule = engineUrl.protocol === 'https:' ? https : http;
+    const req = httpModule.request(engineUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' }
     }, res => {
       let body = '';
       res.on('data', c => { body += c; });
       res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.setTimeout(1000, () => {
+      req.destroy(new Error('Request timed out'));
     });
     req.on('error', reject);
     req.write(JSON.stringify(ksaRequest));

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -6,10 +6,18 @@ const assert = require('assert');
 function startServer(relativePath, port, extraEnv = {}) {
   const fullPath = path.join(__dirname, '..', relativePath);
   const env = { ...process.env, PORT: String(port), ...extraEnv };
-  return spawn('node', [fullPath], { env });
+  const child = spawn('node', [fullPath], { env, stdio: 'inherit' });
+  return child;
 }
 
-function post(port, data) {
+async function stopServer(child) {
+  if (child && child.exitCode === null) {
+    child.kill();
+    await new Promise(resolve => child.once('exit', resolve));
+  }
+}
+
+function post(port, data, raw = false) {
   return new Promise((resolve, reject) => {
     const req = http.request({
       hostname: 'localhost',
@@ -23,28 +31,29 @@ function post(port, data) {
       res.on('end', () => resolve({ statusCode: res.statusCode, body }));
     });
     req.on('error', reject);
-    req.write(JSON.stringify(data));
+    if (raw) req.write(data); else req.write(JSON.stringify(data));
     req.end();
   });
 }
 
+
 (async () => {
-  const enginePort = 9010;
-  const adapterPort = 9011;
+  // Successful forwarding using endpoint URL
+  const enginePort = 19010;
+  const adapterPort = 19011;
   const received = [];
   const engine = http.createServer((req, res) => {
     let body = '';
     req.on('data', c => { body += c; });
     req.on('end', () => {
-      received.push(JSON.parse(body || '{}'));
+      received.push({ path: req.url, body: JSON.parse(body || '{}') });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
     });
   });
   await new Promise(r => engine.listen(enginePort, r));
   const adapter = startServer('servers/ksa/index.cjs', adapterPort, {
-    KSA_ENGINE_HOST: 'localhost',
-    KSA_ENGINE_PORT: String(enginePort)
+    KSA_ENGINE_ENDPOINT: `http://localhost:${enginePort}/engine`
   });
   try {
     await new Promise(r => setTimeout(r, 100));
@@ -53,14 +62,53 @@ function post(port, data) {
     assert.strictEqual(result.statusCode, 200);
     assert.deepStrictEqual(JSON.parse(result.body), { ok: true });
     assert.deepStrictEqual(received[0], {
-      command: 'notify_message',
-      arguments: { msg: 'hello' },
-      requestId: '99'
+      path: '/engine',
+      body: {
+        command: 'notify_message',
+        arguments: { msg: 'hello' },
+        requestId: '99'
+      }
     });
-    console.log('KSA adapter tests passed');
   } finally {
-    adapter.kill();
-    engine.close();
+    await stopServer(adapter);
+    await new Promise(r => engine.close(r));
   }
-})();
 
+  // Engine failure (unreachable)
+  const failPort = 19012;
+  const adapterFailPort = 19013;
+  const adapterFail = startServer('servers/ksa/index.cjs', adapterFailPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(failPort)
+  });
+  try {
+    await new Promise(r => setTimeout(r, 100));
+    const result = await post(adapterFailPort, { method: 'ping', id: '1' });
+    assert.strictEqual(result.statusCode, 502);
+  } finally {
+    await stopServer(adapterFail);
+  }
+
+  // Malformed request
+  const engine2Port = 19014;
+  const engine2 = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise(r => engine2.listen(engine2Port, r));
+  const adapterBadPort = 19015;
+  const adapterBad = startServer('servers/ksa/index.cjs', adapterBadPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(engine2Port)
+  });
+  try {
+    await new Promise(r => setTimeout(r, 100));
+    const badRes = await post(adapterBadPort, '{', true);
+    assert.strictEqual(badRes.statusCode, 400);
+  } finally {
+    await stopServer(adapterBad);
+    await new Promise(r => engine2.close(r));
+  }
+
+  console.log('KSA adapter tests passed');
+})();


### PR DESCRIPTION
## Summary
- prevent hanging engine requests by timing out KSA adapter forwarding
- use high, unique ports in `ksa-adapter.test.cjs`
- gracefully stop spawned servers in the KSA adapter tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880e29fcee8832694e468e72f8e3c01