### PR TITLE
Unify server config

### DIFF
--- a/MCP-PowerShell-Guide.md
+++ b/MCP-PowerShell-Guide.md
@@ -219,15 +219,15 @@ Write-Output "Script completed successfully"
 
 ## Server Configuration
 
-Ports and runtimes for all MCP scripts are now defined in `server-config.json`.
-Use the `-ServerConfigFile` parameter to point scripts at an alternate file.
+Ports and runtimes for all MCP scripts are now defined in `engine-config.json`.
+Use the `-EngineConfigFile` parameter to point scripts at an alternate file.
 
 ```powershell
 # Start the MCP server using settings from a custom file
-.\run-mcp-server.ps1 -ServerConfigFile custom-config.json
+.\run-mcp-server.ps1 -EngineConfigFile custom-config.json
 
 # Launch the entire stack using the same shared config
-.\run-all-mcp-servers.ps1 -ServerConfigFile custom-config.json
+.\run-all-mcp-servers.ps1 -ConfigFile custom-config.json
 ```
 
 ## Troubleshooting PowerShell Issues

--- a/engine-config.json
+++ b/engine-config.json
@@ -1,30 +1,37 @@
 {
   "unity": {
     "port": 8001,
-    "directory": "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server"
+    "directory": "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server",
+    "engine": "node"
   },
   "godot": {
     "port": 8002,
-    "directory": "servers/godot"
+    "directory": "servers/godot",
+    "engine": "dotnet"
   },
   "git": {
     "port": 8080,
-    "directory": "servers/git"
+    "directory": "servers/git",
+    "engine": "node"
   },
   "postgres": {
     "port": 8003,
-    "directory": "servers/postgres"
+    "directory": "servers/postgres",
+    "engine": "node"
   },
   "telemetry": {
     "port": 8090,
-    "directory": "servers/telemetry"
+    "directory": "servers/telemetry",
+    "engine": "node"
   },
   "mcpproxy": {
     "port": 8004,
-    "directory": "servers/mcpProxy"
+    "directory": "servers/mcpProxy",
+    "engine": "node"
   },
   "ksa": {
     "port": 8005,
-    "directory": "servers/ksa"
+    "directory": "servers/ksa",
+    "engine": "node"
   }
 }

--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -2,8 +2,7 @@
 param(
     [ValidateSet('unity','godot','ksa')]
     [string]$Engine = 'unity',
-    [string]$ConfigFile = 'engine-config.json',
-    [string]$ServerConfigFile = 'server-config.json'
+    [string]$ConfigFile = 'engine-config.json'
 )
 
 Write-Host "Starting All MCP Servers..." -ForegroundColor Cyan
@@ -28,16 +27,6 @@ if (Test-Path $ConfigFile) {
     }
 }
 
-# Load shared server configuration for ports and runtimes
-$serverCfg = $null
-if (Test-Path $ServerConfigFile) {
-    try {
-        $serverCfg = Get-Content -Path $ServerConfigFile -Raw | ConvertFrom-Json
-        Write-Host "Using server configuration from $ServerConfigFile" -ForegroundColor Green
-    } catch {
-        Write-Warning "Failed to load server configuration from $ServerConfigFile: $_"
-    }
-}
 
 # Determine ports
 $unityPort = 8001
@@ -56,14 +45,6 @@ if ($engineCfg) {
     if ($engineCfg.ksa.port) { $ksaPort = [int]$engineCfg.ksa.port }
 }
 
-if ($serverCfg) {
-    if ($serverCfg.unity.port) { $unityPort = [int]$serverCfg.unity.port }
-    if ($serverCfg.git.port) { $gitPort = [int]$serverCfg.git.port }
-    if ($serverCfg.postgres.port) { $postgresPort = [int]$serverCfg.postgres.port }
-    if ($serverCfg.telemetry.port) { $telemetryPort = [int]$serverCfg.telemetry.port }
-    if ($serverCfg.mcpproxy.port) { $proxyPort = [int]$serverCfg.mcpproxy.port }
-    if ($serverCfg.ksa.port) { $ksaPort = [int]$serverCfg.ksa.port }
-}
 
 # Function to check server ports
 function Test-ServerPort {
@@ -104,7 +85,7 @@ $ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port $ksaPort
 if (-not $unityRunning) {
     Write-Host "Starting Unity MCP Server..." -ForegroundColor Green
     $unityScript = Join-Path $scriptDir "run-mcp-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile -ServerConfigFile $ServerConfigFile" -NoNewWindow
+    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile" -NoNewWindow
 } else {
     Write-Host "Skipping Unity MCP Server (already running)" -ForegroundColor Yellow
 }

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -10,8 +10,7 @@ param (
     [string]$Engine = "unity",
     [switch]$Monitor,
     [string]$ConfigFile = ".mcp-server-config.json",
-    [string]$EngineConfigFile = "engine-config.json",
-    [string]$ServerConfigFile = "server-config.json"
+    [string]$EngineConfigFile = "engine-config.json"
 )
 
 # Exit immediately if the provided configuration file does not exist so the
@@ -86,27 +85,13 @@ if (Test-Path $EngineConfigFile) {
             if (-not $config.serverPath -and $engineEntry.directory) {
                 $config.serverPath = Join-Path $projectRoot $engineEntry.directory
             }
+            if ($engineEntry.engine) { $config.runtime = $engineEntry.engine }
         }
     } catch {
         Write-Warning "Failed to load engine configuration from $EngineConfigFile: $_"
     }
 }
 
-# Load shared runtime/port settings from the server config file
-if (Test-Path $ServerConfigFile) {
-    try {
-        $serverData = Get-Content -Path $ServerConfigFile -Raw | ConvertFrom-Json
-        $serverEntry = $serverData.$($config.engine)
-        if ($serverEntry) {
-            if (-not $PSBoundParameters.ContainsKey('Port') -and -not $portFromConfig -and $serverEntry.port) {
-                $config.port = [int]$serverEntry.port
-            }
-            if ($serverEntry.engine) { $config.runtime = $serverEntry.engine }
-        }
-    } catch {
-        Write-Warning "Failed to load server configuration from $ServerConfigFile: $_"
-    }
-}
 
 # Ensure a valid port is set, falling back to engine defaults
 if (-not (Test-ValidPort -Port $config.port)) {

--- a/server-config.json
+++ b/server-config.json
@@ -1,9 +1,0 @@
-{
-  "unity": { "port": 8001, "engine": "node" },
-  "godot": { "port": 8002, "engine": "dotnet" },
-  "git": { "port": 8080, "engine": "node" },
-  "postgres": { "port": 8003, "engine": "node" },
-  "telemetry": { "port": 8090, "engine": "node" },
-  "mcpproxy": { "port": 8004, "engine": "node" },
-  "ksa": { "port": 8005, "engine": "node" }
-}


### PR DESCRIPTION
## Summary
- consolidate server and engine settings into `engine-config.json`
- update run scripts to read the unified file
- remove the old `server-config.json`
- refresh documentation for new config usage

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881904c9d9483268a0a97fc78fa4aae