### PR TITLE
Remove redundant npm ci step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       - run: dotnet format --verify-no-changes Godot/TBDSpaceRPG.csproj
       - run: npm ci
       - run: npm run lint
-      - run: npm ci
       - run: npm test
 
   dotnet-tests:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "prelint": "npm ci",
-    "pretest": "npm ci",
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
     "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
 


### PR DESCRIPTION
## Summary
- clean up workflow by removing duplicate `npm ci` step in node-tests job
- avoid implicit npm installs by deleting `prelint` and `pretest` scripts

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881904bfae483268d6d06409e481b34