### PR TITLE
Add ShipUpgradeMenuHelper unit test

### DIFF
--- a/Godot.Tests/Godot.Tests.csproj
+++ b/Godot.Tests/Godot.Tests.csproj
@@ -21,7 +21,9 @@
     <Compile Include="../src/SimpleKeplerOrbits/*.cs" />
     <Compile Include="../src/ShipCustomization/ShipCustomizationManager.cs" />
     <Compile Include="../src/ShipCustomization/SpaceshipMovement.cs" />
+    <Compile Include="../src/ShipCustomization/ShipUpgradeMenuHelper.cs" />
     <Compile Include="test/Tests.cs" />
+    <Compile Include="test/src/ShipUpgradeMenuHelperTests.cs" />
     <Compile Include="test/src/*.cs" />
   </ItemGroup>
 </Project>

--- a/Godot.Tests/test/src/ShipUpgradeMenuHelperTests.cs
+++ b/Godot.Tests/test/src/ShipUpgradeMenuHelperTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public class ShipUpgradeMenuHelperTests : TestClass {
+    public ShipUpgradeMenuHelperTests(Node scene) : base(scene) { }
+
+    [Test]
+    public void CreateTestShipAddsManager() {
+        var helper = new ShipUpgradeMenuHelper();
+        TestScene.AddChild(helper);
+
+        typeof(ShipUpgradeMenuHelper)
+            .GetMethod("CreateTestShip", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(helper, null);
+
+        var manager = typeof(ShipUpgradeMenuHelper)
+            .GetMethod("GetManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(helper, null);
+
+        manager.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- create ShipUpgradeMenuHelperTests.cs to verify CreateTestShip and GetManager
- include ShipUpgradeMenuHelper.cs and the new test file in the Godot.Tests project

## Testing
- `npm run lint`
- `npm test`
- `dotnet build Godot.Tests/Godot.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6882871a4aa08326a29964e7f5f2eaf8