### PR TITLE
Update ship customization group

### DIFF
--- a/Godot.Tests/test/src/ShipUpgradeMenuHelperTests.cs
+++ b/Godot.Tests/test/src/ShipUpgradeMenuHelperTests.cs
@@ -1,0 +1,43 @@
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public partial class ShipUpgradeMenuHelperTests : TestClass {
+    private partial class TestHelper : Node {
+        public void CreateTestShip() {
+            var ship = new CharacterBody3D { Name = "TestShip" };
+            var move = new SpaceshipMovement();
+            var manager = new ShipCustomizationManager { Movement = move };
+            manager.AddToGroup("ShipCustomizationManager");
+            ship.AddChild(move);
+            ship.AddChild(manager);
+            AddChild(ship);
+        }
+
+        public ShipCustomizationManager? GetManager() {
+            foreach (var node in GetTree().GetNodesInGroup("ShipCustomizationManager"))
+                if (node is ShipCustomizationManager mgr)
+                    return mgr;
+            return null;
+        }
+    }
+
+    public ShipUpgradeMenuHelperTests(Node scene) : base(scene) { }
+
+    [Test]
+    public void CreateTestShip_AddsManagerToGroup() {
+        var helper = new TestHelper();
+        TestScene.AddChild(helper);
+        helper.CreateTestShip();
+
+        if (helper.GetChildCount() > 0 && helper.GetChild(0) is Node ship) {
+            helper.RemoveChild(ship);
+            TestScene.AddChild(ship);
+        }
+
+        var manager = helper.GetManager();
+
+        manager.ShouldNotBeNull();
+        manager.ShouldBeOfType<ShipCustomizationManager>();
+    }
+}

--- a/src/ShipCustomization/ShipCustomizationManager.cs
+++ b/src/ShipCustomization/ShipCustomizationManager.cs
@@ -11,6 +11,7 @@ public partial class ShipCustomizationManager : Node
 
     public override void _Ready()
     {
+        AddToGroup("ShipCustomizationManager");
         ApplyUpgrades();
     }
 

--- a/src/ShipCustomization/ShipUpgradeMenuHelper.cs
+++ b/src/ShipCustomization/ShipUpgradeMenuHelper.cs
@@ -31,6 +31,7 @@ public partial class ShipUpgradeMenuHelper : EditorPlugin
         var ship = new CharacterBody3D { Name = "TestShip" };
         var move = new SpaceshipMovement();
         var manager = new ShipCustomizationManager { Movement = move };
+        manager.AddToGroup("ShipCustomizationManager");
         ship.AddChild(move);
         ship.AddChild(manager);
         AddChild(ship);


### PR DESCRIPTION
## Summary
- ensure ShipCustomizationManager adds itself to the `ShipCustomizationManager` group
- add group assignment when helper creates test ship
- add unit test for ship upgrade helper logic

## Testing
- `npm run lint`
- `npm test`
- `dotnet build Godot.Tests/Godot.Tests.csproj`
- `./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish`

------
https://chatgpt.com/codex/tasks/task_e_688287194a348326bf3b2994a4e7317a