### PR TITLE
Update README with group note

### DIFF
--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -283,6 +283,9 @@ The Ship Customization System (implemented according to Section 4.16 of the tech
 2. **ShipCustomizationManager.cs**: Manages upgrade categories and levels
 3. **ShipUpgradeMenuHelper.cs**: Editor script that provides menu items for MCP integration
 
+> **Note**
+> `ShipCustomizationManager` must belong to the `"ShipCustomizationManager"` group so editor menu items can locate it. The provided Godot plugin automatically adds this group when creating a test ship.
+
 ### Testing the Ship Customization System
 
 The following MCP commands can be used to test the Ship Customization System:


### PR DESCRIPTION
## Summary
- document that `ShipCustomizationManager` needs to be in the "ShipCustomizationManager" group
- note that the Godot plugin adds this group when creating a test ship

## Testing
- `n/a` (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6882902c853c83268f143d4586445fb2