### PR TITLE
Switch telemetry logging to async

### DIFF
--- a/servers/telemetry/index.cjs
+++ b/servers/telemetry/index.cjs
@@ -9,8 +9,8 @@ const logDir = path.join(__dirname, 'logs');
 fs.mkdirSync(logDir, { recursive: true });
 const logFile = path.join(logDir, 'events.log');
 
-function logEvent(event) {
-  fs.appendFileSync(logFile, `${JSON.stringify(event)}\n`);
+async function logEvent(event) {
+  await fs.promises.appendFile(logFile, `${JSON.stringify(event)}\n`);
   analytics.computeMetrics(event);
 }
 
@@ -37,7 +37,7 @@ const server = http.createServer((req, res) => {
         res.end('Invalid JSON');
         return;
       }
-      logEvent(event);
+      logEvent(event).catch(logError);
       res.writeHead(200, { 'Content-Type': 'text/plain' });
       res.end('Event received');
     });

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -3,6 +3,18 @@ const { spawn } = require('child_process');
 const path = require('path');
 const assert = require('assert');
 
+function request(port, pathName = '/') {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: 'localhost', port, path: pathName }, res => {
+      let data = '';
+      res.on('data', c => { data += c; });
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 function startServer(relativePath, port, extraEnv = {}) {
   const fullPath = path.join(__dirname, '..', relativePath);
   const env = { ...process.env, PORT: String(port), ...extraEnv };
@@ -36,6 +48,21 @@ function post(port, data, raw = false) {
   });
 }
 
+async function waitForServer(port, timeout = 5000) {
+  const start = Date.now();
+  while (true) {
+    try {
+      await request(port);
+      return;
+    } catch {
+      if (Date.now() - start > timeout) {
+        throw new Error(`Timeout waiting for server on port ${port}`);
+      }
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+}
+
 
 (async () => {
   // Successful forwarding using endpoint URL
@@ -56,7 +83,7 @@ function post(port, data, raw = false) {
     KSA_ENGINE_ENDPOINT: `http://localhost:${enginePort}/engine`
   });
   try {
-    await new Promise(r => setTimeout(r, 100));
+    await waitForServer(adapterPort);
     const mcp = { method: 'notify_message', params: { msg: 'hello' }, id: '99' };
     const result = await post(adapterPort, mcp);
     assert.strictEqual(result.statusCode, 200);
@@ -82,7 +109,7 @@ function post(port, data, raw = false) {
     KSA_ENGINE_PORT: String(failPort)
   });
   try {
-    await new Promise(r => setTimeout(r, 100));
+    await waitForServer(adapterFailPort);
     const result = await post(adapterFailPort, { method: 'ping', id: '1' });
     assert.strictEqual(result.statusCode, 502);
   } finally {
@@ -102,7 +129,7 @@ function post(port, data, raw = false) {
     KSA_ENGINE_PORT: String(engine2Port)
   });
   try {
-    await new Promise(r => setTimeout(r, 100));
+    await waitForServer(adapterBadPort);
     const badRes = await post(adapterBadPort, '{', true);
     assert.strictEqual(badRes.statusCode, 400);
   } finally {


### PR DESCRIPTION
## Summary
- make telemetry `logEvent` async using `fs.promises.appendFile`
- handle promise rejections when logging events
- stabilize KSA adapter tests by waiting for servers to start

## Testing
- `npm run lint`
- `node tests/analytics.test.cjs`
- `node tests/aidirector.test.cjs`
- `node tests/ksa-adapter.test.cjs`
- `node tests/mcp-commands.test.cjs`
- `node tests/server.test.cjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882a3c49a848326884642717f2cf359