### PR TITLE
Add missing upgrade tests

### DIFF
--- a/csharp/GodotStubs/Godot.cs
+++ b/csharp/GodotStubs/Godot.cs
@@ -38,6 +38,7 @@ namespace Godot
         public string Name { get; set; } = string.Empty;
         public Node? Parent { get; private set; }
         public virtual void AddChild(Node node) { node.Parent = this; Children.Add(node); }
+        public void AddToGroup(string group) { }
         public virtual void QueueFree() { }
         public Node? GetParent() => Parent;
         public T? GetNodeOrNull<T>(string path) where T : class => null;

--- a/csharp/ShipCustomization.Tests/ShipCustomizationManagerTests.cs
+++ b/csharp/ShipCustomization.Tests/ShipCustomizationManagerTests.cs
@@ -23,4 +23,24 @@ public class ShipCustomizationManagerTests
         Assert.AreEqual(1, manager.SpeedLevel);
         Assert.AreEqual(20f, movement.MaxSpeed);
     }
+
+    [Test]
+    public void UpgradeRotation_IncreasesLevelAndAppliesToMovement()
+    {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeRotation();
+        Assert.AreEqual(2, manager.RotationLevel);
+        Assert.AreEqual(180f, movement.RotationSpeed);
+    }
+
+    [Test]
+    public void UpgradeBraking_IncreasesLevelAndAppliesToMovement()
+    {
+        var movement = new SpaceshipMovement();
+        var manager = new ShipCustomizationManager { Movement = movement };
+        manager.UpgradeBraking();
+        Assert.AreEqual(2, manager.BrakingLevel);
+        Assert.AreEqual(10f, movement.BrakingForce);
+    }
 }

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -4,26 +4,6 @@ const path = require('path');
 const assert = require('assert');
 const getFreePort = require('./helpers/port.cjs');
 
-function waitForServer(port, timeout = 5000) {
-  return new Promise((resolve, reject) => {
-    const start = Date.now();
-    (function check() {
-      const req = http.request({ hostname: 'localhost', port }, res => {
-        res.resume();
-        resolve();
-      });
-      req.on('error', err => {
-        if (Date.now() - start > timeout) {
-          reject(err);
-        } else {
-          setTimeout(check, 100);
-        }
-      });
-      req.end();
-    })();
-  });
-}
-
 function request(port, pathName = '/') {
   return new Promise((resolve, reject) => {
     const req = http.request({ hostname: 'localhost', port, path: pathName }, res => {


### PR DESCRIPTION
## Summary
- test rotation & braking upgrades for ship movement
- implement `AddToGroup` stub to compile tests
- remove duplicate `waitForServer` helper in ksa adapter tests

## Testing
- `npm run lint`
- `npm test`
- `dotnet format --verify-no-changes csharp/OrbitalMechanics.sln`
- `dotnet format --verify-no-changes Godot/TBDSpaceRPG.csproj`
- `dotnet test csharp/ShipCustomization.Tests/ShipCustomization.Tests.csproj --verbosity normal`
- `dotnet test csharp/OrbitalMechanics.Tests/OrbitalMechanics.Tests.csproj --verbosity normal`
- `dotnet test servers/godot.Tests/GodotServer.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6882c63e01288326a8384dc2fe51582d