### PR TITLE
Improve MCP client error logging

### DIFF
--- a/Godot.Tests/test/src/McpClientLogHelper.cs
+++ b/Godot.Tests/test/src/McpClientLogHelper.cs
@@ -1,0 +1,4 @@
+public partial class McpClient {
+    public string? LastLoggedError { get; private set; }
+    partial void LogError(string message) => LastLoggedError = message;
+}

--- a/Godot.Tests/test/src/McpClientTests.cs
+++ b/Godot.Tests/test/src/McpClientTests.cs
@@ -32,6 +32,33 @@ public class McpClientTests : TestClass {
         body.ShouldContain("\"menuPath\":\"Test/Path\"");
     }
 
+    [Test]
+    public async Task SendCommand_LogsErrorOnFailure() {
+        int port = GetFreePort();
+        string url = $"http://localhost:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(url);
+        listener.Start();
+
+        var client = new McpClient { Endpoint = url };
+        TestScene.AddChild(client);
+        var sendTask = client.SendCommand("Test/Fail");
+
+        var context = await listener.GetContextAsync();
+        using (var reader = new StreamReader(context.Request.InputStream))
+            await reader.ReadToEndAsync();
+        context.Response.StatusCode = 500;
+        using var writer = new StreamWriter(context.Response.OutputStream);
+        writer.Write("fail");
+        writer.Flush();
+        context.Response.Close();
+        listener.Stop();
+
+        await sendTask;
+        client.LastLoggedError.ShouldContain("500");
+        client.LastLoggedError.ShouldContain("fail");
+    }
+
     private static int GetFreePort() {
         var l = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
         l.Start();

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -44,7 +45,19 @@ public partial class McpClient : Control
             req.QueueFree();
             return;
         }
-        await ToSignal(req, HttpRequest.SignalName.RequestCompleted);
+        var signalData = await ToSignal(req, HttpRequest.SignalName.RequestCompleted);
+        var statusCode = req.GetResponseCode();
+        if (statusCode != 200)
+        {
+            string bodyText = string.Empty;
+            if (signalData is Godot.Collections.Array arr && arr.Count >= 4 && arr[3] is byte[] bytes)
+                bodyText = Encoding.UTF8.GetString(bytes);
+            var msg = $"HTTP error {statusCode}: {bodyText}";
+            GD.PrintErr(msg);
+            LogError(msg);
+        }
         req.QueueFree();
     }
+
+    partial void LogError(string message);
 }

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -24,17 +24,6 @@ function waitForServer(port, timeout = 5000) {
   });
 }
 
-function request(port, pathName = '/') {
-  return new Promise((resolve, reject) => {
-    const req = http.request({ hostname: 'localhost', port, path: pathName }, res => {
-      let data = '';
-      res.on('data', c => { data += c; });
-      res.on('end', () => resolve(data));
-    });
-    req.on('error', reject);
-    req.end();
-  });
-}
 
 function startServer(relativePath, port, extraEnv = {}) {
   const fullPath = path.join(__dirname, '..', relativePath);
@@ -69,20 +58,7 @@ function post(port, data, raw = false) {
   });
 }
 
-async function waitForServer(port, timeout = 5000) {
-  const start = Date.now();
-  while (true) {
-    try {
-      await request(port);
-      return;
-    } catch {
-      if (Date.now() - start > timeout) {
-        throw new Error(`Timeout waiting for server on port ${port}`);
-      }
-      await new Promise(r => setTimeout(r, 100));
-    }
-  }
-}
+
 
 
 (async () => {


### PR DESCRIPTION
## Summary
- log non-200 responses from `McpClient` with status code and response body
- expose a partial method for tests to capture logged errors
- test error logging when server returns 500
- remove duplicate helper and unused function from KSA adapter test to satisfy eslint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882c63d8b788326821b22e4632bcae4