### PR TITLE
Fix async analytics test

### DIFF
--- a/tests/analytics.test.cjs
+++ b/tests/analytics.test.cjs
@@ -13,7 +13,10 @@ if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
       'not json',
       JSON.stringify({ type: 'generation_advanced', generation: 3 })
     ].join('\n');
-    fs.writeFileSync(logPath, lines);
+    await fs.promises.writeFile(logPath, lines);
+
+    const logContents = await fs.promises.readFile(logPath, 'utf8');
+    assert.ok(logContents.includes('test'));
 
     const metrics = analytics.parseLogFile(logPath);
     assert.strictEqual(metrics.totalEvents, 2);


### PR DESCRIPTION
## Summary
- update analytics test to await async fs writes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c92bf2648326afeca88248563ac0