### PR TITLE
Add scripts to manage MCP server processes

### DIFF
--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -16,6 +16,12 @@ if (-not $scriptDir) {
     $scriptDir = $PWD.Path
 }
 
+# Directory to store PID files for the launched servers
+$pidDir = Join-Path $scriptDir 'tmp/pids'
+if (-not (Test-Path $pidDir)) {
+    New-Item -ItemType Directory -Path $pidDir -Force | Out-Null
+}
+
 # Load engine configuration
 $engineCfg = $null
 if (Test-Path $ConfigFile) {
@@ -85,7 +91,8 @@ $ksaRunning = Test-ServerPort -ServerName "KSA Adapter" -Port $ksaPort
 if (-not $unityRunning) {
     Write-Host "Starting Unity MCP Server..." -ForegroundColor Green
     $unityScript = Join-Path $scriptDir "run-mcp-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile" -NoNewWindow
+    $unityProcess = Start-Process PowerShell -ArgumentList "-File `"$unityScript`" -Engine $Engine -Port $unityPort -EngineConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'unity.pid') -Value $unityProcess.Id
 } else {
     Write-Host "Skipping Unity MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -94,7 +101,8 @@ if (-not $unityRunning) {
 if (-not $gitRunning) {
     Write-Host "Starting Git MCP Server..." -ForegroundColor Green
     $gitScript = Join-Path $scriptDir "run-git-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$gitScript`" -Port $gitPort -ConfigFile $ConfigFile" -NoNewWindow
+    $gitProcess = Start-Process PowerShell -ArgumentList "-File `"$gitScript`" -Port $gitPort -ConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'git.pid') -Value $gitProcess.Id
 } else {
     Write-Host "Skipping Git MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -103,7 +111,8 @@ if (-not $gitRunning) {
 if (-not $postgresRunning) {
     Write-Host "Starting Postgres MCP Server..." -ForegroundColor Green
     $postgresScript = Join-Path $scriptDir "run-postgres-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$postgresScript`" -Port $postgresPort -ConfigFile $ConfigFile" -NoNewWindow
+    $postgresProcess = Start-Process PowerShell -ArgumentList "-File `"$postgresScript`" -Port $postgresPort -ConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'postgres.pid') -Value $postgresProcess.Id
 } else {
     Write-Host "Skipping Postgres MCP Server (already running)" -ForegroundColor Yellow
 }
@@ -112,7 +121,8 @@ if (-not $postgresRunning) {
 if (-not $telemetryRunning) {
     Write-Host "Starting Telemetry Server..." -ForegroundColor Green
     $telemetryScript = Join-Path $scriptDir "run-telemetry-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$telemetryScript`" -Port $telemetryPort -ConfigFile $ConfigFile" -NoNewWindow
+    $telemetryProcess = Start-Process PowerShell -ArgumentList "-File `"$telemetryScript`" -Port $telemetryPort -ConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'telemetry.pid') -Value $telemetryProcess.Id
 } else {
     Write-Host "Skipping Telemetry Server (already running)" -ForegroundColor Yellow
 }
@@ -121,7 +131,8 @@ if (-not $telemetryRunning) {
 if (-not $proxyRunning) {
     Write-Host "Starting MCP Proxy Server..." -ForegroundColor Green
     $proxyScript = Join-Path $scriptDir "run-mcpproxy-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$proxyScript`" -Port $proxyPort -ConfigFile $ConfigFile" -NoNewWindow
+    $proxyProcess = Start-Process PowerShell -ArgumentList "-File `"$proxyScript`" -Port $proxyPort -ConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'proxy.pid') -Value $proxyProcess.Id
 } else {
     Write-Host "Skipping MCP Proxy Server (already running)" -ForegroundColor Yellow
 }
@@ -130,7 +141,8 @@ if (-not $proxyRunning) {
 if (-not $ksaRunning) {
     Write-Host "Starting KSA Adapter..." -ForegroundColor Green
     $ksaScript = Join-Path $scriptDir "run-ksa-server.ps1"
-    Start-Process PowerShell -ArgumentList "-File `"$ksaScript`" -Port $ksaPort -ConfigFile $ConfigFile" -NoNewWindow
+    $ksaProcess = Start-Process PowerShell -ArgumentList "-File `"$ksaScript`" -Port $ksaPort -ConfigFile $ConfigFile" -NoNewWindow -PassThru
+    Set-Content -Path (Join-Path $pidDir 'ksa.pid') -Value $ksaProcess.Id
 } else {
     Write-Host "Skipping KSA Adapter (already running)" -ForegroundColor Yellow
 }

--- a/stop-all-mcp-servers.ps1
+++ b/stop-all-mcp-servers.ps1
@@ -1,0 +1,61 @@
+# PowerShell script to stop all MCP servers launched via run-all-mcp-servers.ps1
+
+param(
+    [string]$PidDirectory
+)
+
+Write-Host "Stopping MCP servers..." -ForegroundColor Cyan
+
+# Determine script directory
+$scriptDir = $PSScriptRoot
+if (-not $scriptDir) {
+    $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+if (-not $scriptDir) {
+    $scriptDir = $PWD.Path
+}
+
+if (-not $PidDirectory) {
+    $PidDirectory = Join-Path $scriptDir 'tmp/pids'
+}
+
+if (-not (Test-Path $PidDirectory)) {
+    Write-Host "PID directory not found: $PidDirectory" -ForegroundColor Yellow
+    return
+}
+
+$pidFiles = Get-ChildItem -Path $PidDirectory -Filter '*.pid' -ErrorAction SilentlyContinue
+if (-not $pidFiles) {
+    Write-Host "No PID files found." -ForegroundColor Yellow
+    return
+}
+
+foreach ($file in $pidFiles) {
+    try {
+        $pid = Get-Content -Path $file.FullName | Select-Object -First 1
+        if ($pid) {
+            $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Host "Stopping $($file.BaseName) (PID: $pid)..." -ForegroundColor Yellow
+                Stop-Process -Id $pid -ErrorAction SilentlyContinue
+                if (Get-Process -Id $pid -ErrorAction SilentlyContinue) {
+                    Start-Sleep -Seconds 3
+                    if (Get-Process -Id $pid -ErrorAction SilentlyContinue) {
+                        Write-Host "Forcing termination of PID $pid" -ForegroundColor Red
+                        Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+                    }
+                }
+                Write-Host "Stopped $($file.BaseName)" -ForegroundColor Green
+            } else {
+                Write-Host "Process with PID $pid not running" -ForegroundColor Yellow
+            }
+        }
+    } catch {
+        Write-Warning "Failed to stop process in $($file.Name): $_"
+    } finally {
+        Remove-Item $file.FullName -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "All servers stopped." -ForegroundColor Cyan
+


### PR DESCRIPTION
## Summary
- write PID files when starting MCP servers
- add a new script to stop the servers using those PIDs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882c92b344883269956ff85cb89a247