### PR TITLE
Implement retry logic in KSA adapter

### DIFF
--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -23,7 +23,10 @@ function translateMcpToKsa(mcp) {
   };
 }
 
-function forwardToEngine(ksaRequest) {
+const maxRetries = parseInt(process.env.KSA_MAX_RETRIES || '3', 10);
+const retryDelay = parseInt(process.env.KSA_RETRY_DELAY || '100', 10);
+
+function sendOnce(ksaRequest) {
   return new Promise((resolve, reject) => {
     const httpModule = engineUrl.protocol === 'https:' ? https : http;
     const req = httpModule.request(engineUrl, {
@@ -41,6 +44,21 @@ function forwardToEngine(ksaRequest) {
     req.write(JSON.stringify(ksaRequest));
     req.end();
   });
+}
+
+async function forwardToEngine(ksaRequest) {
+  let attempt = 0;
+  let delay = retryDelay;
+  for (;;) {
+    try {
+      return await sendOnce(ksaRequest);
+    } catch (err) {
+      attempt += 1;
+      if (attempt >= maxRetries) throw err;
+      await new Promise(r => setTimeout(r, delay));
+      delay *= 2;
+    }
+  }
 }
 
 const server = http.createServer((req, res) => {

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -99,6 +99,35 @@ function post(port, data, raw = false) {
     await new Promise(r => engine.close(r));
   }
 
+  // Engine starts after delay to test retry logic
+  const latePort = await getFreePort();
+  const adapterRetryPort = await getFreePort();
+  const adapterRetry = startServer('servers/ksa/index.cjs', adapterRetryPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(latePort),
+    KSA_MAX_RETRIES: '5',
+    KSA_RETRY_DELAY: '100'
+  });
+  let engineLate;
+  try {
+    await waitForServer(adapterRetryPort);
+    const start = Date.now();
+    const responsePromise = post(adapterRetryPort, { method: 'ping', id: '2' });
+    await new Promise(r => setTimeout(r, 300));
+    engineLate = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{}');
+    });
+    await new Promise(r => engineLate.listen(latePort, r));
+    const result = await responsePromise;
+    const duration = Date.now() - start;
+    assert.strictEqual(result.statusCode, 200);
+    assert.ok(duration >= 300);
+  } finally {
+    if (engineLate) await new Promise(r => engineLate.close(r));
+    await stopServer(adapterRetry);
+  }
+
   // Engine failure (unreachable)
   const failPort = await getFreePort();
   const adapterFailPort = await getFreePort();
@@ -108,8 +137,11 @@ function post(port, data, raw = false) {
   });
   try {
     await waitForServer(adapterFailPort);
+    const startFail = Date.now();
     const result = await post(adapterFailPort, { method: 'ping', id: '1' });
+    const durationFail = Date.now() - startFail;
     assert.strictEqual(result.statusCode, 502);
+    assert.ok(durationFail >= 200);
   } finally {
     await stopServer(adapterFail);
   }


### PR DESCRIPTION
## Summary
- add exponential backoff retry logic to `servers/ksa/index.cjs`
- test KSA adapter retry behaviour and error handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e2e3b06883269056d858832eb428