### PR TITLE
Add engine selection to PowerShell clients

### DIFF
--- a/execute-mcp-command.ps1
+++ b/execute-mcp-command.ps1
@@ -1,8 +1,12 @@
 # PowerShell script to execute MCP commands
+# Example:
+#   ./execute-mcp-command.ps1 -menuPath "GameObject/Create Empty" -Engine unity
 param (
     [Parameter(Mandatory=$true)]
     [string]$menuPath,
     [string]$Endpoint,
+    [ValidateSet('godot','unity')]
+    [string]$Engine = 'godot',
     [string]$ConfigFile = "engine-config.json"
 )
 
@@ -15,25 +19,31 @@ function Test-ValidPort {
 }
 
 $uri = $null
+$port = $null
 
 if ($PSBoundParameters.ContainsKey('Endpoint')) {
     $uri = $Endpoint
-} elseif (Test-Path $ConfigFile) {
-    try {
-        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
-        if ($cfg.unity -and $cfg.unity.port) {
-            $uri = "http://localhost:$($cfg.unity.port)/mcp"
+    $port = ([System.Uri]$uri).Port
+} else {
+    if (Test-Path $ConfigFile) {
+        try {
+            $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+            if ($cfg.$Engine -and $cfg.$Engine.port) {
+                $port = [int]$cfg.$Engine.port
+            }
+        } catch {
+            Write-Warning "Failed to load engine config from $ConfigFile: $_"
         }
-    } catch {
-        Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+    if (-not $port) {
+        $port = if ($Engine -eq 'godot') { 8002 } else { 8001 }
+    }
+    $uri = "http://localhost:$port/mcp"
 }
 
-if (-not $uri) {
-    $uri = "http://localhost:8001/mcp"
+if (-not $port) {
+    $port = ([System.Uri]$uri).Port
 }
-
-$port = ([System.Uri]$uri).Port
 if (-not (Test-ValidPort -Port $port)) {
     Write-Error "Invalid port: $port"
     exit 1

--- a/execute-mcp-message.ps1
+++ b/execute-mcp-message.ps1
@@ -1,13 +1,17 @@
-# PowerShell script to send a test message to Unity console
+# PowerShell script to send a test message to the MCP server
+# Example:
+#   ./execute-mcp-message.ps1 -message "Hello" -Engine unity
 param (
     [Parameter(Mandatory=$true)]
     [string]$message,
     [string]$Endpoint,
+    [ValidateSet('godot','unity')]
+    [string]$Engine = 'godot',
     [string]$ConfigFile = "engine-config.json"
 )
 
 # Output what we're doing
-Write-Host "Sending message to Unity: $message"
+Write-Host "Sending message to MCP server: $message"
 
 function Test-ValidPort {
     param([int]$Port)
@@ -15,25 +19,31 @@ function Test-ValidPort {
 }
 
 $uri = $null
+$port = $null
 
 if ($PSBoundParameters.ContainsKey('Endpoint')) {
     $uri = $Endpoint
-} elseif (Test-Path $ConfigFile) {
-    try {
-        $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
-        if ($cfg.unity -and $cfg.unity.port) {
-            $uri = "http://localhost:$($cfg.unity.port)/mcp"
+    $port = ([System.Uri]$uri).Port
+} else {
+    if (Test-Path $ConfigFile) {
+        try {
+            $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+            if ($cfg.$Engine -and $cfg.$Engine.port) {
+                $port = [int]$cfg.$Engine.port
+            }
+        } catch {
+            Write-Warning "Failed to load engine config from $ConfigFile: $_"
         }
-    } catch {
-        Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+    if (-not $port) {
+        $port = if ($Engine -eq 'godot') { 8002 } else { 8001 }
+    }
+    $uri = "http://localhost:$port/mcp"
 }
 
-if (-not $uri) {
-    $uri = "http://localhost:8001/mcp"
+if (-not $port) {
+    $port = ([System.Uri]$uri).Port
 }
-
-$port = ([System.Uri]$uri).Port
 if (-not (Test-ValidPort -Port $port)) {
     Write-Error "Invalid port: $port"
     exit 1

--- a/mcpWebSocketClient-advanced.ps1
+++ b/mcpWebSocketClient-advanced.ps1
@@ -1,5 +1,7 @@
 # Advanced MCP WebSocket Client for TBD Space Game
-# This script connects to the MCP Unity WebSocket server and can send various command types
+# This script connects to the MCP server and can send various command types
+# Example:
+#   ./mcpWebSocketClient-advanced.ps1 -commandType menu_item -menuPath "MCP/Test/Ping" -Engine unity
 
 param (
     [Parameter(Mandatory=$false)]
@@ -25,10 +27,30 @@ param (
     
     [Parameter(Mandatory=$false)]
     [string]$commandType = "menu_item",
-    
+
     [Parameter(Mandatory=$false)]
-    [string]$serverUrl = "ws://localhost:8001/McpUnity"
+    [string]$serverUrl = $null,
+
+    [ValidateSet('godot','unity')]
+    [string]$Engine = 'godot',
+
+    [string]$ConfigFile = 'engine-config.json'
+
 )
+
+if (-not $serverUrl) {
+    $port = $null
+    if (Test-Path $ConfigFile) {
+        try {
+            $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+            if ($cfg.$Engine -and $cfg.$Engine.port) { $port = [int]$cfg.$Engine.port }
+        } catch {
+            Write-Warning "Failed to load engine config from $ConfigFile: $_"
+        }
+    }
+    if (-not $port) { $port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
+    $serverUrl = if ($Engine -eq 'godot') { "ws://localhost:$port/" } else { "ws://localhost:$port/McpUnity" }
+}
 
 function Test-ValidPort {
     param([int]$Port)
@@ -228,7 +250,7 @@ $operationDesc = switch ($commandType) {
     default { "unknown operation type: $commandType" }
 }
 
-Write-Host "Connecting to MCP Unity server and performing operation: $operationDesc"
+Write-Host "Connecting to MCP server and performing operation: $operationDesc"
 
 # Connect to WebSocket
 $webSocket = Connect-ToWebSocket -url $serverUrl
@@ -246,7 +268,7 @@ if ($webSocket -ne $null) {
             if ($success) {
                 # Wait for response
                 Start-Sleep -Milliseconds 500
-                Write-Host "Command execution initiated in Unity"
+                Write-Host "Command execution initiated"
                 
                 # Optionally receive response if needed
                 # $response = Receive-WebSocketMessage -webSocket $webSocket

--- a/mcpWebSocketClient-simple.ps1
+++ b/mcpWebSocketClient-simple.ps1
@@ -1,13 +1,20 @@
-# Simplified PowerShell WebSocket client for MCP Unity server
+# Simplified PowerShell WebSocket client for the MCP server
+# Example:
+#   ./mcpWebSocketClient-simple.ps1 -menuPath "MCP/Test/Ping" -Engine unity
 param (
     [Parameter(Mandatory=$false)]
     [string]$menuPath,
-    
+
     [Parameter(Mandatory=$false)]
     [string]$message,
-    
+
     [Parameter(Mandatory=$false)]
-    [string]$logType = "Log"  # Can be: Log, Warning, Error
+    [string]$logType = "Log"  # Can be: Log, Warning, Error,
+
+    [ValidateSet('godot','unity')]
+    [string]$Engine = 'godot',
+
+    [string]$ConfigFile = 'engine-config.json'
 )
 
 function Test-ValidPort {
@@ -25,12 +32,28 @@ if (!$menuPath -and !$message) {
 $operationType = if ($menuPath) { "execute_menu_item" } else { "notify_message" }
 $targetName = if ($menuPath) { $menuPath } else { $message }
 
-Write-Host "Connecting to MCP Unity server and performing operation: $operationType with target: $targetName"
+Write-Host "Connecting to MCP server and performing operation: $operationType with target: $targetName"
 
 try {
     # Create client WebSocket
     $client = New-Object System.Net.WebSockets.ClientWebSocket
-    $uri = New-Object System.Uri("ws://localhost:8001/McpUnity")
+
+    $port = $null
+    if (Test-Path $ConfigFile) {
+        try {
+            $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+            if ($cfg.$Engine -and $cfg.$Engine.port) { $port = [int]$cfg.$Engine.port }
+        } catch {
+            Write-Warning "Failed to load engine config from $ConfigFile: $_"
+        }
+    }
+    if (-not $port) { $port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
+    $url = if ($Engine -eq 'godot') {
+        "ws://localhost:$port/"
+    } else {
+        "ws://localhost:$port/McpUnity"
+    }
+    $uri = New-Object System.Uri($url)
 
     if (-not (Test-ValidPort -Port $uri.Port)) {
         Write-Host "Invalid port in WebSocket URI: $($uri.Port)" -ForegroundColor Red
@@ -80,7 +103,7 @@ try {
         Start-Sleep -Seconds 1
         
         # No waiting for response in this simplified version
-        Write-Host "Command execution initiated in Unity" -ForegroundColor Green
+        Write-Host "Command execution initiated" -ForegroundColor Green
         
         # Close the connection
         $closeTask = $client.CloseAsync([System.Net.WebSockets.WebSocketCloseStatus]::NormalClosure, "Closing", [System.Threading.CancellationToken]::None)

--- a/test-menu.ps1
+++ b/test-menu.ps1
@@ -1,7 +1,7 @@
 # test-menu.ps1
 # Purpose: Test MCP menu items by sending commands to the MCP server
-# Usage: .\test-menu.ps1 -MenuPath "Path/To/Menu/Item"
-#        .\test-menu.ps1 -MenuPaths "Path1","Path2","Path3"
+# Usage: .\test-menu.ps1 -MenuPath "Path/To/Menu/Item" [-Engine godot|unity]
+#        .\test-menu.ps1 -MenuPaths "Path1","Path2","Path3" [-Engine unity]
 
 param (
     [Parameter(Mandatory=$true, ParameterSetName="SinglePath")]
@@ -10,7 +10,12 @@ param (
     [Parameter(Mandatory=$true, ParameterSetName="MultiplePaths")]
     [string[]]$MenuPaths,
     
-    [int]$Port = 8001,
+    [int]$Port = 0,
+
+    [ValidateSet('godot','unity')]
+    [string]$Engine = 'godot',
+
+    [string]$ConfigFile = 'engine-config.json',
 
     [switch]$Verbose
 )
@@ -18,6 +23,18 @@ param (
 function Test-ValidPort {
     param([int]$Port)
     return ($Port -ge 1 -and $Port -le 65535)
+}
+
+if (-not $Port) {
+    if (Test-Path $ConfigFile) {
+        try {
+            $cfg = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+            if ($cfg.$Engine -and $cfg.$Engine.port) { $Port = [int]$cfg.$Engine.port }
+        } catch {
+            Write-Warning "Failed to load engine config from $ConfigFile: $_"
+        }
+    }
+    if (-not $Port) { $Port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
 }
 
 if (-not (Test-ValidPort -Port $Port)) {
@@ -28,7 +45,11 @@ if (-not (Test-ValidPort -Port $Port)) {
 Add-Type -AssemblyName System.Net.WebSockets.Client
 
 # Define constants and variables
-$webSocketUrl = "ws://localhost:$Port/McpUnity"
+$webSocketUrl = if ($Engine -eq 'godot') {
+    "ws://localhost:$Port/"
+} else {
+    "ws://localhost:$Port/McpUnity"
+}
 $logFile = Join-Path $PSScriptRoot "mcp-client.log"
 $timeoutMs = 10000 # 10 seconds
 
@@ -186,7 +207,7 @@ function Send-WebSocketRequest {
                         Write-Log "Warning: Response ID ($($responseObj.id)) does not match request ID ($requestId)" "WARNING"
                     }
                     
-                    Write-Log "Command execution initiated in Unity (ID: $($responseObj.id))" "SUCCESS"
+                    Write-Log "Command execution initiated (ID: $($responseObj.id))" "SUCCESS"
                     Write-Log "Response: $response" "INFO"
                     return $true
                 }
@@ -296,7 +317,7 @@ if (-not (Test-Server)) {
     
     $startServer = Read-Host "Would you like to start the server now? (y/n)"
     if ($startServer -eq "y") {
-        & "$PSScriptRoot\run-mcp-server.ps1" -Port $Port
+        & "$PSScriptRoot\run-mcp-server.ps1" -Port $Port -Engine $Engine
         Start-Sleep -Seconds 2 # Give the server time to start
     }
     else {


### PR DESCRIPTION
## Summary
- add `-Engine` parameter to PowerShell scripts
- load `engine-config.json` to choose proper port
- adjust websocket/HTTP URLs for Godot or Unity
- update help comments and examples

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883d288cae48326a707ca8a01cdd176