### PR TITLE
Switch default engine to Godot

### DIFF
--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -1,7 +1,7 @@
 # PowerShell script to start all MCP servers
 param(
     [ValidateSet('unity','godot','ksa')]
-    [string]$Engine = 'unity',
+    [string]$Engine = 'godot',
     [string]$ConfigFile = 'engine-config.json'
 )
 
@@ -149,7 +149,11 @@ if (-not $ksaRunning) {
 
 Write-Host "All MCP servers have been started!" -ForegroundColor Cyan
 Write-Host "Use the following servers in Cursor:" -ForegroundColor White
-Write-Host "- mcp-unity: ws://localhost:$unityPort/McpUnity" -ForegroundColor White
+if ($Engine -eq 'godot') {
+    Write-Host "- mcp-godot: ws://localhost:$unityPort/mcp" -ForegroundColor White
+} else {
+    Write-Host "- mcp-unity: ws://localhost:$unityPort/McpUnity" -ForegroundColor White
+}
 Write-Host "- git: http://localhost:$gitPort" -ForegroundColor White
 Write-Host "- postgres: http://localhost:$postgresPort" -ForegroundColor White
 Write-Host "- telemetry: http://localhost:$telemetryPort" -ForegroundColor White


### PR DESCRIPTION
## Summary
- default `$Engine` to `'godot'` in run-all-mcp-servers.ps1
- show `mcp-godot` in output when no engine is specified

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e461aa488326b2b70b8b57b22bd7