### PR TITLE
Add Godot server websocket test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@eslint/js": "^9.31.0",
         "eslint": "^9.31.0",
-        "globals": "^16.3.0"
+        "globals": "^16.3.0",
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1095,6 +1096,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "private": true,
   "scripts": {
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
-    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
-
+    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && node tests/godot-server.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
     "lint": "eslint servers tests",
     "start:core-mcp": "node servers/core-mcp/index.cjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
     "eslint": "^9.31.0",
-    "globals": "^16.3.0"
+    "globals": "^16.3.0",
+    "ws": "^8.18.3"
   },
   "type": "module"
 }

--- a/tests/godot-server.test.cjs
+++ b/tests/godot-server.test.cjs
@@ -1,0 +1,65 @@
+const { spawn, spawnSync } = require('child_process');
+const path = require('path');
+const assert = require('assert');
+const WS = require('ws');
+const getFreePort = require('./helpers/port.cjs');
+
+if (spawnSync('dotnet', ['--version']).error) {
+  console.log('dotnet not found, skipping Godot server test');
+  process.exit(0);
+}
+
+function waitForWS(port, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    (function attempt() {
+      const ws = new WS(`ws://localhost:${port}/`);
+      ws.once('open', () => {
+        ws.close();
+        resolve();
+      });
+      ws.once('error', err => {
+        if (Date.now() - start > timeout) {
+          reject(err);
+        } else {
+          setTimeout(attempt, 100);
+        }
+      });
+    })();
+  });
+}
+
+(async () => {
+  const port = await getFreePort();
+  const projPath = path.join(__dirname, '..', 'servers', 'godot', 'GodotServer.csproj');
+  const server = spawn('dotnet', ['run', '--project', projPath, '--no-build'], {
+    env: { ...process.env, PORT: String(port) },
+    stdio: 'inherit'
+  });
+  try {
+    await waitForWS(port);
+    const ws = new WS(`ws://localhost:${port}/`);
+    await new Promise((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+    const item = 'MCP/Test';
+    const id = '1';
+    ws.send(JSON.stringify({ type: 'execute_menu_item', id, parameters: { item } }));
+    const resp = await new Promise((resolve, reject) => {
+      ws.once('message', data => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      ws.once('error', reject);
+    });
+    assert.deepStrictEqual(resp.result, { executed: item });
+    ws.close();
+    console.log('Godot server tests passed');
+  } finally {
+    server.kill();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a websocket integration test for the dotnet Godot server
- install the `ws` dev dependency
- run the new test from `npm test`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e4629e388326834f1c53259bba80