### PR TITLE
Add basic orbit demo

### DIFF
--- a/Documentation/Technical/Godot_Migration_Steps.md
+++ b/Documentation/Technical/Godot_Migration_Steps.md
@@ -11,3 +11,4 @@ These steps outline how to move existing assets and workflows to the Godot pipel
    ```
 5. Unity runtime scripts have been removed. Use the C# scripts in the Godot project to handle gameplay logic.
 6. Run the Godot project from the editor and verify that it connects to the MCP servers at startup.
+7. Open the `Flight` scene to observe the basic orbit system. The scene now contains an `OrbitManager` and a `CelestialBody`. When running the vertical slice, the ship automatically follows a circular orbit around the body.

--- a/Godot/Scenes/Flight.tscn
+++ b/Godot/Scenes/Flight.tscn
@@ -1,10 +1,14 @@
-[gd_scene load_steps=5 format=3]
+[gd_scene load_steps=8 format=3]
 
 [ext_resource path="res://Scenes/Ship.tscn" type="PackedScene" id="1"]
 [ext_resource path="res://Scenes/UI/Hud.tscn" type="PackedScene" id="2"]
 [ext_resource path="res://Scenes/StationDock.tscn" type="PackedScene" id="3"]
+[ext_resource path="res://src/OrbitalMechanics/CelestialBody.cs" type="Script" id="4"]
+[ext_resource path="res://src/OrbitalMechanics/OrbitManager.cs" type="Script" id="5"]
+[ext_resource path="res://Scripts/FlightOrbitSetup.cs" type="Script" id="6"]
 
 [node name="Flight" type="Node3D" index="0"]
+script = ExtResource("6")
 
 [node name="Ship" parent="." instance=ExtResource("1")]
 
@@ -16,3 +20,9 @@ current = true
 [node name="UI" parent="." instance=ExtResource("2")]
 
 [node name="StationDock" parent="." instance=ExtResource("3")]
+
+[node name="OrbitManager" type="Node" parent="."]
+script = ExtResource("5")
+
+[node name="Planet" type="Node3D" parent="."]
+script = ExtResource("4")

--- a/Godot/Scripts/FlightOrbitSetup.cs
+++ b/Godot/Scripts/FlightOrbitSetup.cs
@@ -1,0 +1,22 @@
+using Godot;
+using OrbitalMechanics;
+
+public partial class FlightOrbitSetup : Node
+{
+    [Export] public NodePath ShipPath = "Ship";
+    [Export] public NodePath BodyPath = "Planet";
+    [Export] public double OrbitRadius = 20.0;
+
+    public override void _Ready()
+    {
+        var ship = GetNode<Node3D>(ShipPath);
+        var body = GetNode<CelestialBody>(BodyPath);
+        if (ship == null || body == null) return;
+
+        var follower = new OrbitFollower();
+        AddChild(follower);
+        follower.SetOrbit(new OrbitPlanner().PlanCircularOrbit(body, OrbitRadius));
+        ship.GetParent()?.RemoveChild(ship);
+        follower.AddChild(ship);
+    }
+}

--- a/src/OrbitalMechanics/OrbitPlanner.cs
+++ b/src/OrbitalMechanics/OrbitPlanner.cs
@@ -25,5 +25,24 @@ namespace OrbitalMechanics
 
             return new OrbitData { orbit = transferOrbit };
         }
+
+        /// <summary>
+        /// Creates a simple circular orbit around the specified body.
+        /// </summary>
+        public OrbitData PlanCircularOrbit(CelestialBody body, double radius)
+        {
+            var orbit = new KeplerOrbit
+            {
+                semiMajorAxis = radius,
+                eccentricity = 0,
+                inclination = 0,
+                argumentOfPeriapsis = 0,
+                longitudeOfAscendingNode = 0,
+                meanAnomalyAtEpoch = 0,
+                gravitationalParameter = body.InitialOrbit.orbit.gravitationalParameter
+            };
+
+            return new OrbitData { orbit = orbit };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `CelestialBody` and `OrbitManager` nodes to the flight scene
- implement `OrbitPlanner.PlanCircularOrbit` helper
- create `FlightOrbitSetup` to arrange the ship in orbit
- document how to see the orbit demo in the migration steps

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883f16cb5808326afa1106ac1153512