### PR TITLE
Support multiple WebSocket clients in Godot server

### DIFF
--- a/servers/godot.Tests/WebSocketTests.cs
+++ b/servers/godot.Tests/WebSocketTests.cs
@@ -110,6 +110,34 @@ public class WebSocketTests
         Assert.That(ws.State, Is.EqualTo(WebSocketState.Closed));
     }
 
+    [Test]
+    public async Task TwoClientsCanReceiveResponses()
+    {
+        using var ws1 = new ClientWebSocket();
+        using var ws2 = new ClientWebSocket();
+        var uri = new Uri($"ws://localhost:{_port}/");
+        await ws1.ConnectAsync(uri, CancellationToken.None);
+        await ws2.ConnectAsync(uri, CancellationToken.None);
+
+        var req1 = Encoding.UTF8.GetBytes("{\"type\":\"execute_menu_item\",\"id\":\"1\",\"parameters\":{\"item\":\"first\"}}");
+        var req2 = Encoding.UTF8.GetBytes("{\"type\":\"execute_menu_item\",\"id\":\"2\",\"parameters\":{\"item\":\"second\"}}");
+        await ws1.SendAsync(req1, WebSocketMessageType.Text, true, CancellationToken.None);
+        await ws2.SendAsync(req2, WebSocketMessageType.Text, true, CancellationToken.None);
+
+        var buffer1 = new byte[1024];
+        var buffer2 = new byte[1024];
+        var result1Task = ws1.ReceiveAsync(buffer1, CancellationToken.None);
+        var result2Task = ws2.ReceiveAsync(buffer2, CancellationToken.None);
+        await Task.WhenAll(result1Task, result2Task);
+        var resp1 = JsonDocument.Parse(Encoding.UTF8.GetString(buffer1, 0, result1Task.Result.Count));
+        var resp2 = JsonDocument.Parse(Encoding.UTF8.GetString(buffer2, 0, result2Task.Result.Count));
+
+        Assert.That(resp1.RootElement.GetProperty("id").GetString(), Is.EqualTo("1"));
+        Assert.That(resp1.RootElement.GetProperty("result").GetProperty("executed").GetString(), Is.EqualTo("first"));
+        Assert.That(resp2.RootElement.GetProperty("id").GetString(), Is.EqualTo("2"));
+        Assert.That(resp2.RootElement.GetProperty("result").GetProperty("executed").GetString(), Is.EqualTo("second"));
+    }
+
     private static int GetFreePort()
     {
         var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);

--- a/servers/godot/Program.cs
+++ b/servers/godot/Program.cs
@@ -53,6 +53,8 @@ public class SimpleWebSocketServer : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private Task? _listenTask;
     private readonly IDictionary<string, IMcpCommandHandler> _handlers;
+    private readonly List<WebSocket> _clients = new();
+    private readonly object _clientsLock = new();
 
     public int Port { get; }
 
@@ -96,24 +98,31 @@ public class SimpleWebSocketServer : IDisposable
             }
 
             var wsContext = await ctx.AcceptWebSocketAsync(null);
+            lock (_clientsLock)
+            {
+                _clients.Add(wsContext.WebSocket);
+            }
             _ = Task.Run(() => HandleConnection(wsContext.WebSocket, token));
         }
     }
 
     private async Task HandleConnection(WebSocket socket, CancellationToken token)
     {
-        var buffer = new byte[1024];
-        while (socket.State == WebSocketState.Open && !token.IsCancellationRequested)
+        try
         {
-            WebSocketReceiveResult result;
-            try
+            var buffer = new byte[1024];
+            while (socket.State == WebSocketState.Open && !token.IsCancellationRequested)
             {
-                result = await socket.ReceiveAsync(buffer, token);
-            }
-            catch
-            {
-                break;
-            }
+                WebSocketReceiveResult result;
+                try
+                {
+                    result = await socket.ReceiveAsync(buffer, token);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Receive failed: {ex.Message}");
+                    break;
+                }
 
             if (result.MessageType == WebSocketMessageType.Close)
             {
@@ -144,12 +153,43 @@ public class SimpleWebSocketServer : IDisposable
                 Console.Error.WriteLine($"Failed to process packet: {ex.Message}");
             }
         }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Connection error: {ex.Message}");
+        }
+        finally
+        {
+            lock (_clientsLock)
+            {
+                _clients.Remove(socket);
+            }
+            try
+            {
+                socket.Dispose();
+            }
+            catch { }
+        }
     }
 
     public void Stop()
     {
         _cts.Cancel();
         _listener.Stop();
+        List<WebSocket> clientsCopy;
+        lock (_clientsLock)
+        {
+            clientsCopy = new List<WebSocket>(_clients);
+        }
+        foreach (var ws in clientsCopy)
+        {
+            try
+            {
+                if (ws.State == WebSocketState.Open)
+                    ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server shutting down", CancellationToken.None).Wait();
+            }
+            catch { }
+        }
         try
         {
             _listenTask?.Wait();


### PR DESCRIPTION
## Summary
- track connected WebSocket clients with a list instead of a concurrent dictionary
- isolate connection errors per client and close sockets gracefully
- close all client connections on server stop
- test that two clients can connect simultaneously and both get responses

## Testing
- `npm run lint`
- `npm test` (Godot and Unity tests skipped due to missing tools)


------
https://chatgpt.com/codex/tasks/task_e_6883f16d66a08326b57555ac1b5fe308