### PR TITLE
Add schema validation to KSA adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "tbdspacerpg",
       "version": "1.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
         "eslint": "^9.31.0",
@@ -105,6 +108,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -117,6 +137,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.31.0",
@@ -259,16 +286,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -514,6 +540,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -526,6 +569,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -608,7 +658,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -624,6 +673,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -800,10 +865,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -988,6 +1052,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "globals": "^16.3.0",
     "ws": "^8.18.3"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "ajv": "^8.17.1"
+  }
 }

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -1,5 +1,8 @@
 const http = require('http');
 const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
 const { logError } = require('../utils.cjs');
 
 const port = process.env.PORT || 8005;
@@ -14,6 +17,11 @@ try {
   console.warn('Invalid KSA_ENGINE_ENDPOINT:', err);
   engineUrl = new URL(`http://${engineHost}:${enginePort}/`);
 }
+
+const schemaPath = path.join(__dirname, 'schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const ajv = new Ajv();
+const validateKsaRequest = ajv.compile(schema.definitions.request);
 
 function translateMcpToKsa(mcp) {
   return {
@@ -66,24 +74,31 @@ const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', async () => {
+      let mcp;
       try {
-        const mcp = JSON.parse(body || '{}');
-        const ksaRequest = translateMcpToKsa(mcp);
-        try {
-          const engineRes = await forwardToEngine(ksaRequest);
-          res.writeHead(engineRes.statusCode || 500, engineRes.headers);
-          res.end(engineRes.body);
-        } catch (err) {
-          console.error(err);
-          res.writeHead(502, { 'Content-Type': 'text/plain' });
-          res.end('Failed to reach KSA engine');
-        }
+        mcp = JSON.parse(body || '{}');
       } catch (err) {
         console.error(err);
-
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('Invalid JSON');
         return;
+      }
+
+      const ksaRequest = translateMcpToKsa(mcp);
+      if (!validateKsaRequest(ksaRequest)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid request', details: validateKsaRequest.errors }));
+        return;
+      }
+
+      try {
+        const engineRes = await forwardToEngine(ksaRequest);
+        res.writeHead(engineRes.statusCode || 500, engineRes.headers);
+        res.end(engineRes.body);
+      } catch (err) {
+        console.error(err);
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Failed to reach KSA engine');
       }
     });
     return;

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -146,6 +146,28 @@ function post(port, data, raw = false) {
     await stopServer(adapterFail);
   }
 
+  // Invalid payload (schema validation)
+  const engine3Port = await getFreePort();
+  const engine3 = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise(r => engine3.listen(engine3Port, r));
+  const adapterInvalidPort = await getFreePort();
+  const adapterInvalid = startServer('servers/ksa/index.cjs', adapterInvalidPort, {
+    KSA_ENGINE_HOST: 'localhost',
+    KSA_ENGINE_PORT: String(engine3Port)
+  });
+  try {
+    await waitForServer(adapterInvalidPort);
+    const invalidRes = await post(adapterInvalidPort, { method: 'ping' });
+    assert.strictEqual(invalidRes.statusCode, 400);
+    assert.ok(/Invalid request/.test(invalidRes.body));
+  } finally {
+    await stopServer(adapterInvalid);
+    await new Promise(r => engine3.close(r));
+  }
+
   // Malformed request
   const engine2Port = await getFreePort();
   const engine2 = http.createServer((req, res) => {
@@ -162,6 +184,7 @@ function post(port, data, raw = false) {
     await waitForServer(adapterBadPort);
     const badRes = await post(adapterBadPort, '{', true);
     assert.strictEqual(badRes.statusCode, 400);
+    assert.ok(/Invalid JSON/.test(badRes.body));
   } finally {
     await stopServer(adapterBad);
     await new Promise(r => engine2.close(r));


### PR DESCRIPTION
## Summary
- load KSA schema with Ajv and validate KSA requests
- return HTTP 400 with message when schema validation fails or JSON is invalid
- test schema validation path
- add Ajv dependency

## Testing
- `npx eslint servers tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68868560aa1c8326b3deea909128eb8b