### PR TITLE
Add asset export scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,9 +76,9 @@ jobs:
     needs: unity-tests
     steps:
       - uses: actions/checkout@v3
-      - name: Run glTF export
+      - name: Export glTF assets
         shell: pwsh
-        run: ./export-gltf.ps1
+        run: ./export-assets.ps1
       - name: Archive glTF Assets
         uses: actions/upload-artifact@v3
         with:

--- a/README-MCP-Integration.md
+++ b/README-MCP-Integration.md
@@ -538,7 +538,7 @@ Godot is now the main runtime engine for TBD Space Game. Assets exported from Un
 A playable vertical slice built with **Godot 4 (.NET)** demonstrates the core systems. Unity runtime scripts were removed to focus on this workflow.
 
 ### Exporting glTF Assets
-Use a glTF exporter (such as Unity's glTFast or Blender's exporter) to convert prefabs and models. Export them into `Assets_glTF/` so both Unity and Godot consume the same files.
+Run `./export-assets.ps1` (or `./export-assets.sh` on Unix) to automatically export prefabs and models using Unity or Blender. The script copies `.gltf` and `.glb` files into `Assets_glTF/` and `Godot/Assets_glTF/`.
 
 ### Command Line Asset Exporters
 The Unity project included lightweight exporters that ran without opening the editor. These files are now archived on the `unity-archive` branch. If you need them, check out that branch and run:
@@ -551,13 +551,13 @@ The exporter builds `Exporters.csproj` and writes a sample `.gltf` file to `Asse
 
 ### Unified Export Tool
 
-Run the following PowerShell script to copy exported assets into the Godot project. It will run the Unity exporters when they are available:
+Run the following script to export assets and copy them into the Godot project:
 
 ```powershell
-./run-exporters-to-godot.ps1
+./export-assets.ps1
 ```
 
-The script copies glTF files into `Godot/Assets_glTF/` and gameplay data into `Godot/Gameplay_Data/` so the assets are ready for import when you open the Godot editor. If the Unity exporters are missing, checkout the `unity-archive` branch to access them.
+For Unix systems use `./export-assets.sh`.
 
 ### Starting Servers for Godot
 Run all MCP servers configured for Godot with:

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Start all MCP servers with Godot:
 ```powershell
 ./run-all-mcp-servers.ps1 -Engine godot
 ```
+
+Export glTF assets from Unity or Blender:
+```powershell
+./export-assets.ps1
+```
+For Unix systems use `./export-assets.sh` instead.

--- a/Unity-MCP-Integration-Manual.md
+++ b/Unity-MCP-Integration-Manual.md
@@ -389,7 +389,7 @@ If Unity updates its packages, run `restart-mcp-after-unity-update.ps1`:
 ## Godot Workflow
 
 ### Exporting glTF Assets
-Use the glTFast plugin or Blender\x27s exporter to convert Unity prefabs or Blender models into `.gltf` files. Place the exports in `Assets_glTF/`.
+Run `./export-assets.ps1` (or `./export-assets.sh` on Unix) to export prefabs and models using Unity or Blender. The script places the resulting files in `Assets_glTF/` and `Godot/Assets_glTF/`.
 
 ### Launching Servers for Godot
 Start all MCP services with Godot-specific settings:

--- a/export-assets.ps1
+++ b/export-assets.ps1
@@ -1,0 +1,30 @@
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$unityCmd = Get-Command unity-editor -ErrorAction SilentlyContinue
+$blenderCmd = Get-Command blender -ErrorAction SilentlyContinue
+$projectPath = Join-Path $repoRoot 'TBD SpaceGame/TBD SpaceGame'
+$blenderScript = Join-Path $repoRoot 'blender/export-assets.py'
+$blenderProject = Join-Path $repoRoot 'blender/project.blend'
+
+if ($unityCmd) {
+    Write-Host 'Running Unity glTF exporter...'
+    & $unityCmd.Source -batchmode -nographics -quit -projectPath $projectPath -executeMethod Exporters.ExportGLTF
+} elseif ($blenderCmd) {
+    if (Test-Path $blenderScript -and Test-Path $blenderProject) {
+        Write-Host 'Running Blender glTF exporter...'
+        & $blenderCmd.Source -b $blenderProject -P $blenderScript
+    } else {
+        Write-Warning 'Blender exporter not found. Skipping glTF export.'
+    }
+} else {
+    Write-Warning 'Neither unity-editor nor blender found. Skipping glTF export.'
+}
+
+$destRoot = Join-Path $repoRoot 'Assets_glTF'
+$godotDest = Join-Path $repoRoot 'Godot/Assets_glTF'
+New-Item -ItemType Directory -Force -Path $destRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $godotDest | Out-Null
+
+Get-ChildItem $projectPath -Recurse -Include *.gltf,*.glb -ErrorAction SilentlyContinue | ForEach-Object {
+    Copy-Item $_.FullName -Destination $destRoot -Force
+    Copy-Item $_.FullName -Destination $godotDest -Force
+}

--- a/export-assets.sh
+++ b/export-assets.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+repo_root="$(cd "$(dirname "$0")" && pwd)"
+project_path="$repo_root/TBD SpaceGame/TBD SpaceGame"
+blender_script="$repo_root/blender/export-assets.py"
+blender_project="$repo_root/blender/project.blend"
+
+if command -v unity-editor >/dev/null 2>&1; then
+    echo "Running Unity glTF exporter..."
+    unity-editor -batchmode -nographics -quit -projectPath "$project_path" -executeMethod Exporters.ExportGLTF
+elif command -v blender >/dev/null 2>&1; then
+    if [[ -f "$blender_script" && -f "$blender_project" ]]; then
+        echo "Running Blender glTF exporter..."
+        blender -b "$blender_project" -P "$blender_script"
+    else
+        echo "Blender exporter not found. Skipping glTF export."
+    fi
+else
+    echo "Neither unity-editor nor blender found. Skipping glTF export."
+fi
+
+dest_root="$repo_root/Assets_glTF"
+godot_dest="$repo_root/Godot/Assets_glTF"
+mkdir -p "$dest_root" "$godot_dest"
+
+find "$project_path" \( -name '*.gltf' -o -name '*.glb' \) -type f 2>/dev/null | while read -r file; do
+    cp "$file" "$dest_root" || true
+    cp "$file" "$godot_dest" || true
+done


### PR DESCRIPTION
## Summary
- add new export-assets.ps1 and export-assets.sh
- mention new script in README
- document new workflow in README-MCP-Integration and Unity manual
- update GitHub workflow to use export-assets.ps1

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886dbeb5bd08326b860988659f922fc