### PR TITLE
Implement MCP error logging

### DIFF
--- a/Godot.Tests/test/src/McpClientLogHelper.cs
+++ b/Godot.Tests/test/src/McpClientLogHelper.cs
@@ -1,4 +1,4 @@
 public partial class McpClient {
     public string? LastLoggedError { get; private set; }
-    partial void LogError(string message) => LastLoggedError = message;
+    partial void LogErrorExtra(string message) => LastLoggedError = message;
 }

--- a/Godot/Scripts/FlightOrbitSetup.cs
+++ b/Godot/Scripts/FlightOrbitSetup.cs
@@ -1,4 +1,5 @@
 using Godot;
+
 using OrbitalMechanics;
 
 public partial class FlightOrbitSetup : Node

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -59,5 +60,27 @@ public partial class McpClient : Control
         req.QueueFree();
     }
 
-    partial void LogError(string message);
+    partial void LogErrorExtra(string message);
+
+    partial void LogError(string message)
+    {
+        GD.PrintErr(message);
+        _ = SendTelemetry(message);
+        LogErrorExtra(message);
+    }
+
+    private static async Task SendTelemetry(string message)
+    {
+        try
+        {
+            using var client = new HttpClient();
+            var json = JsonSerializer.Serialize(new { type = "godot_error", message });
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            await client.PostAsync("http://localhost:8090/event", content);
+        }
+        catch (System.Exception e)
+        {
+            GD.PrintErr($"Failed to send telemetry: {e.Message}");
+        }
+    }
 }

--- a/servers/godot/GodotServer.csproj
+++ b/servers/godot/GodotServer.csproj
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- implement `LogError` to print and forward telemetry
- allow tests to hook logging via `LogErrorExtra`
- adapt test helper to match new partial hook
- fix whitespace in `FlightOrbitSetup`
- make Godot server project runnable

## Testing
- `dotnet format --verify-no-changes Godot/TBDSpaceRPG.csproj`
- `npm ci`
- `npm run lint`
- `dotnet build servers/godot/GodotServer.csproj`
- `node tests/godot-server.test.cjs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e58287fc8326a70f5287a69e12a7