### PR TITLE
Handle null json inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
-    "test": "node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && node tests/godot-server.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
+    "test": "node tests/utils.test.cjs && node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && node tests/godot-server.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
     "lint": "eslint servers tests",
     "start:core-mcp": "node servers/core-mcp/index.cjs"
   },

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -3,7 +3,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
-const { logError } = require('../utils.cjs');
+const { logError, parseJson } = require('../utils.cjs');
 
 const port = process.env.PORT || 8005;
 const engineHost = process.env.KSA_ENGINE_HOST || 'localhost';
@@ -74,11 +74,8 @@ const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', chunk => { body += chunk; });
     req.on('end', async () => {
-      let mcp;
-      try {
-        mcp = JSON.parse(body || '{}');
-      } catch (err) {
-        console.error(err);
+      const mcp = parseJson(body);
+      if (!mcp) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('Invalid JSON');
         return;

--- a/servers/utils.cjs
+++ b/servers/utils.cjs
@@ -3,8 +3,9 @@ function logError(err) {
 }
 
 function parseJson(body) {
+  if (!body || !String(body).trim()) return null;
   try {
-    return JSON.parse(body || '{}');
+    return JSON.parse(body);
   } catch (err) {
     logError(err);
     return null;

--- a/tests/aidirector.test.cjs
+++ b/tests/aidirector.test.cjs
@@ -49,6 +49,13 @@ function request(port, options = {}) {
       body: '{',
     });
     assert.strictEqual(bad.statusCode, 400);
+    const empty = await request(port, {
+      method: 'POST',
+      path: '/command',
+      headers: { 'Content-Type': 'application/json' },
+      body: '',
+    });
+    assert.strictEqual(empty.statusCode, 400);
 
     console.log('AI Director tests passed');
   } finally {

--- a/tests/ksa-adapter.test.cjs
+++ b/tests/ksa-adapter.test.cjs
@@ -185,6 +185,8 @@ function post(port, data, raw = false) {
     const badRes = await post(adapterBadPort, '{', true);
     assert.strictEqual(badRes.statusCode, 400);
     assert.ok(/Invalid JSON/.test(badRes.body));
+    const emptyRes = await post(adapterBadPort, '', true);
+    assert.strictEqual(emptyRes.statusCode, 400);
   } finally {
     await stopServer(adapterBad);
     await new Promise(r => engine2.close(r));

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -116,8 +116,12 @@ function post(port, pathName, data) {
     assert.deepStrictEqual(JSON.parse(list2), []);
     const badCreate = await send(corePort, 'POST', '/postgres/crew', '{');
     assert.strictEqual(badCreate.statusCode, 400);
+    const emptyCreate = await send(corePort, 'POST', '/postgres/crew', '');
+    assert.strictEqual(emptyCreate.statusCode, 400);
     const badUpdate = await send(corePort, 'PUT', '/postgres/crew/1', '{');
     assert.strictEqual(badUpdate.statusCode, 400);
+    const emptyUpdate = await send(corePort, 'PUT', '/postgres/crew/1', '');
+    assert.strictEqual(emptyUpdate.statusCode, 400);
     const listAfterBad = await request(corePort, '/postgres/crew');
     assert.deepStrictEqual(JSON.parse(listAfterBad), []);
     const telemetryResponse = await request(corePort, '/telemetry');
@@ -134,6 +138,8 @@ function post(port, pathName, data) {
     assert.strictEqual(postResult.statusCode, 200);
     const badTelemetry = await post(corePort, '/telemetry/event', '{');
     assert.strictEqual(badTelemetry.statusCode, 400);
+    const emptyTelemetry = await post(corePort, '/telemetry/event', '');
+    assert.strictEqual(emptyTelemetry.statusCode, 400);
     const telemetryHealth = await request(corePort, '/telemetry');
     assert.strictEqual(telemetryHealth, 'Telemetry server placeholder');
 

--- a/tests/utils.test.cjs
+++ b/tests/utils.test.cjs
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { parseJson } = require('../servers/utils.cjs');
+
+assert.strictEqual(parseJson(''), null);
+assert.strictEqual(parseJson('   '), null);
+assert.strictEqual(parseJson('{'), null);
+assert.deepStrictEqual(parseJson('{"x":1}'), { x: 1 });
+
+console.log('Utils tests passed');


### PR DESCRIPTION
## Summary
- return `null` from `parseJson` for empty or invalid JSON
- update KSA adapter to use `parseJson`
- ensure various servers reject empty bodies
- extend tests for empty payloads and add new `utils` test
- run `npm install` and linter/tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688784af7d18832686f654041dcc5816