### PR TITLE
Centralize port config

### DIFF
--- a/execute-mcp-command.ps1
+++ b/execute-mcp-command.ps1
@@ -36,7 +36,12 @@ if ($PSBoundParameters.ContainsKey('Endpoint')) {
         }
     }
     if (-not $port) {
-        $port = if ($Engine -eq 'godot') { 8002 } else { 8001 }
+        $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+        if ($Engine -eq 'godot') {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
+        } else {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+        }
     }
     $uri = "http://localhost:$port/mcp"
 }

--- a/execute-mcp-message.ps1
+++ b/execute-mcp-message.ps1
@@ -36,7 +36,12 @@ if ($PSBoundParameters.ContainsKey('Endpoint')) {
         }
     }
     if (-not $port) {
-        $port = if ($Engine -eq 'godot') { 8002 } else { 8001 }
+        $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+        if ($Engine -eq 'godot') {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
+        } else {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+        }
     }
     $uri = "http://localhost:$port/mcp"
 }

--- a/mcpWebSocketClient-advanced.ps1
+++ b/mcpWebSocketClient-advanced.ps1
@@ -48,7 +48,14 @@ if (-not $serverUrl) {
             Write-Warning "Failed to load engine config from $ConfigFile: $_"
         }
     }
-    if (-not $port) { $port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
+    if (-not $port) {
+        $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+        if ($Engine -eq 'godot') {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
+        } else {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+        }
+    }
     $serverUrl = if ($Engine -eq 'godot') { "ws://localhost:$port/" } else { "ws://localhost:$port/McpUnity" }
 }
 

--- a/mcpWebSocketClient-simple.ps1
+++ b/mcpWebSocketClient-simple.ps1
@@ -47,7 +47,14 @@ try {
             Write-Warning "Failed to load engine config from $ConfigFile: $_"
         }
     }
-    if (-not $port) { $port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
+    if (-not $port) {
+        $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+        if ($Engine -eq 'godot') {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
+        } else {
+            $port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+        }
+    }
     $url = if ($Engine -eq 'godot') {
         "ws://localhost:$port/"
     } else {

--- a/restart-mcp-after-unity-update.ps1
+++ b/restart-mcp-after-unity-update.ps1
@@ -219,7 +219,9 @@ Write-Host "===== MCP Server Restart After Unity Update ====="
 Stop-McpNodeProcesses
 
 # Step 2: Free up the port
-Free-Port -Port 8001
+$portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+$Port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+Free-Port -Port $Port
 
 # Step 3: Validate MCP configuration
 $configValid = Test-McpConfig
@@ -232,11 +234,11 @@ if (-not $configValid) {
 $serverPath = "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server"
 
 # Step 5: Start the MCP server
-$serverStarted = Start-McpServer -ServerPath $serverPath -Port 8001
+$serverStarted = Start-McpServer -ServerPath $serverPath -Port $Port
 
 if ($serverStarted) {
     # Step 6: Test the connection
-    $connected = Test-McpServerConnection -Port 8001 -Retries 10 -RetryDelay 2000
+    $connected = Test-McpServerConnection -Port $Port -Retries 10 -RetryDelay 2000
     
     if ($connected) {
         Write-Host "MCP server is now running and ready to accept connections from Unity."

--- a/run-all-mcp-servers.ps1
+++ b/run-all-mcp-servers.ps1
@@ -35,12 +35,13 @@ if (Test-Path $ConfigFile) {
 
 
 # Determine ports
-$unityPort = 8001
-$gitPort = 8080
-$postgresPort = 8003
-$telemetryPort = 8090
-$proxyPort = 8004
-$ksaPort = 8005
+$portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+$unityPort = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+$gitPort = [int](node -e "const p=require(process.argv[1]);console.log(p.git);" $portsPath)
+$postgresPort = [int](node -e "const p=require(process.argv[1]);console.log(p.postgres);" $portsPath)
+$telemetryPort = [int](node -e "const p=require(process.argv[1]);console.log(p.telemetry);" $portsPath)
+$proxyPort = [int](node -e "const p=require(process.argv[1]);console.log(p.mcpproxy);" $portsPath)
+$ksaPort = [int](node -e "const p=require(process.argv[1]);console.log(p.ksa);" $portsPath)
 
 if ($engineCfg) {
     if ($engineCfg.unity.port) { $unityPort = [int]$engineCfg.unity.port }

--- a/run-git-server.ps1
+++ b/run-git-server.ps1
@@ -1,5 +1,5 @@
 param(
-    [int]$Port = 8080,
+    [int]$Port,
     [string]$ServerPath,
     [string]$ConfigFile = "engine-config.json"
 )
@@ -9,9 +9,8 @@ function Test-ValidPort {
     return ($Port -ge 1 -and $Port -le 65535)
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($PSBoundParameters.ContainsKey('Port') -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
-
 }
 
 $scriptDir = $PSScriptRoot
@@ -28,6 +27,13 @@ if (Test-Path $ConfigFile) {
     } catch {
         Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+}
+if (-not $Port) {
+    $portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+    $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.git);" $portsPath)
+}
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/git'

--- a/run-ksa-server.ps1
+++ b/run-ksa-server.ps1
@@ -1,7 +1,7 @@
 # Starts the KSA adapter server. The script now reports an error and exits if
 # the configuration file or server path are missing.
 param(
-    [int]$Port = 8005,
+    [int]$Port,
     [string]$ServerPath,
     [string]$ConfigFile = "engine-config.json"
 )
@@ -11,7 +11,7 @@ function Test-ValidPort {
     return ($Port -ge 1 -and $Port -le 65535)
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($PSBoundParameters.ContainsKey('Port') -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 
@@ -34,6 +34,13 @@ if (Test-Path $ConfigFile) {
     } catch {
         Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+}
+if (-not $Port) {
+    $portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+    $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.ksa);" $portsPath)
+}
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/ksa'

--- a/run-mcp-server.ps1
+++ b/run-mcp-server.ps1
@@ -110,10 +110,11 @@ if ($RandomPort) {
 
 # Ensure a valid port is set, falling back to engine defaults
 if (-not (Test-ValidPort -Port $config.port)) {
+    $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
     if ($config.engine -eq 'godot') {
-        $config.port = 8002
+        $config.port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
     } else {
-        $config.port = 8001
+        $config.port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
     }
 }
 

--- a/run-mcpproxy-server.ps1
+++ b/run-mcpproxy-server.ps1
@@ -1,6 +1,6 @@
 
 param(
-    [int]$Port = 8004,
+    [int]$Port,
     [string]$ProxyPath,
     [string]$ConfigFile = "engine-config.json"
 )
@@ -23,6 +23,14 @@ if (Test-Path $ConfigFile) {
         Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
 }
+if (-not $Port) {
+    $portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+    $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.mcpproxy);" $portsPath)
+}
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port: $Port. Must be between 1 and 65535."
+    exit 1
+}
 if (-not $ProxyPath) {
     # Default to the "servers/mcpProxy" directory relative to this script
     $ProxyPath = Join-Path $scriptDir 'servers/mcpProxy'
@@ -33,7 +41,7 @@ function Test-ValidPort {
     return $Port -ge 1 -and $Port -le 65535
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($PSBoundParameters.ContainsKey('Port') -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port: $Port. Must be between 1 and 65535."
     exit 1
 }

--- a/run-postgres-server.ps1
+++ b/run-postgres-server.ps1
@@ -1,5 +1,5 @@
 param(
-    [int]$Port = 8003,
+    [int]$Port,
     [string]$ServerPath,
     [string]$ConfigFile = "engine-config.json"
 )
@@ -9,9 +9,8 @@ function Test-ValidPort {
     return ($Port -ge 1 -and $Port -le 65535)
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($PSBoundParameters.ContainsKey('Port') -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
-
 }
 
 $scriptDir = $PSScriptRoot
@@ -28,6 +27,13 @@ if (Test-Path $ConfigFile) {
     } catch {
         Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+}
+if (-not $Port) {
+    $portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+    $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.postgres);" $portsPath)
+}
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/postgres'

--- a/run-telemetry-server.ps1
+++ b/run-telemetry-server.ps1
@@ -1,5 +1,5 @@
 param(
-    [int]$Port = 8090,
+    [int]$Port,
     [string]$ServerPath,
     [string]$ConfigFile = "engine-config.json"
 )
@@ -9,7 +9,7 @@ function Test-ValidPort {
     return ($Port -ge 1 -and $Port -le 65535)
 }
 
-if (-not (Test-ValidPort -Port $Port)) {
+if ($PSBoundParameters.ContainsKey('Port') -and -not (Test-ValidPort -Port $Port)) {
     Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 
@@ -27,6 +27,13 @@ if (Test-Path $ConfigFile) {
     } catch {
         Write-Warning "Failed to load engine config from $ConfigFile: $_"
     }
+}
+if (-not $Port) {
+    $portsPath = Join-Path $scriptDir 'servers/ports.cjs'
+    $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.telemetry);" $portsPath)
+}
+if (-not (Test-ValidPort -Port $Port)) {
+    Write-Error "Invalid port number $Port. Port must be between 1 and 65535." -ErrorAction Stop
 }
 if (-not $ServerPath) {
     $ServerPath = Join-Path $scriptDir 'servers/telemetry'

--- a/safe-mcp-restart.ps1
+++ b/safe-mcp-restart.ps1
@@ -7,7 +7,8 @@ Write-Host "Starting MCP server safely..."
 $serverPath = "TBD SpaceGame/TBD SpaceGame/Library/PackageCache/com.gamelovers.mcp-unity@3acfb232f564/Server"
 
 # Set environment variable for the port
-$env:UNITY_PORT = "8001"
+$portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+$env:UNITY_PORT = node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath
 
 # Check if we're in the correct directory
 $currentDir = Get-Location
@@ -31,7 +32,7 @@ if (-not (Test-Path $serverIndex)) {
 
 Start-Process -FilePath "node" -ArgumentList "\"$serverIndex\"" -NoNewWindow
 
-Write-Host "MCP server started on port 8001. You can now reconnect from Unity."
+Write-Host "MCP server started on port $env:UNITY_PORT. You can now reconnect from Unity."
 Write-Host ""
 Write-Host "IMPORTANT: Use the V2 menu items in Unity to avoid conflicts:"
 Write-Host "- MCP/Ship/V2/Create Test Ship"

--- a/servers/aidirector/index.cjs
+++ b/servers/aidirector/index.cjs
@@ -1,7 +1,8 @@
 const http = require('http');
 const { logError, parseJson } = require('../utils.cjs');
+const { aidirector: defaultPort } = require('../ports.cjs');
 
-const port = process.env.PORT || 8100;
+const port = process.env.PORT || defaultPort || 8100;
 
 const server = http.createServer((req, res) => {
   if (req.method === 'GET' && req.url === '/') {

--- a/servers/core-mcp/index.cjs
+++ b/servers/core-mcp/index.cjs
@@ -3,8 +3,9 @@ const fs = require('fs');
 const path = require('path');
 const analytics = require('../telemetry/analytics.cjs');
 const { parseJson, logError } = require('../utils.cjs');
+const { core: defaultPort } = require('../ports.cjs');
 
-const port = process.env.PORT || 8100;
+const port = process.env.PORT || defaultPort || 8100;
 
 // --- Git state ---
 

--- a/servers/git/index.cjs
+++ b/servers/git/index.cjs
@@ -1,6 +1,7 @@
 const http = require('http');
 const { logError } = require('../utils.cjs');
-const port = process.env.PORT || 8080;
+const { git: defaultPort } = require('../ports.cjs');
+const port = process.env.PORT || defaultPort;
 
 function sendJson(res, obj) {
   res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -4,8 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
 const { logError } = require('../utils.cjs');
+const { ksa: defaultPort } = require('../ports.cjs');
 
-const port = process.env.PORT || 8005;
+const port = process.env.PORT || defaultPort;
 const engineHost = process.env.KSA_ENGINE_HOST || 'localhost';
 const enginePort = process.env.KSA_ENGINE_PORT || 9000;
 const engineEndpoint = process.env.KSA_ENGINE_ENDPOINT;

--- a/servers/mcpProxy/dist/src/index.js
+++ b/servers/mcpProxy/dist/src/index.js
@@ -1,6 +1,7 @@
 const http = require('http');
+const { mcpproxy: defaultPort } = require('../../ports.cjs');
 
-const port = process.env.PORT || 8004;
+const port = process.env.PORT || defaultPort;
 
 const server = http.createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/servers/ports.cjs
+++ b/servers/ports.cjs
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const configPath = path.join(__dirname, '..', 'engine-config.json');
+let ports = {};
+try {
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  for (const [name, value] of Object.entries(config)) {
+    if (value && typeof value.port === 'number') {
+      ports[name] = value.port;
+    }
+  }
+} catch (err) {
+  console.warn('Failed to read engine-config.json:', err);
+}
+module.exports = ports;

--- a/servers/postgres/index.cjs
+++ b/servers/postgres/index.cjs
@@ -1,6 +1,7 @@
 const http = require('http');
 const { logError, parseJson } = require('../utils.cjs');
-const port = process.env.PORT || 8003;
+const { postgres: defaultPort } = require('../ports.cjs');
+const port = process.env.PORT || defaultPort;
 
 const crew = [];
 let nextId = 1;

--- a/servers/telemetry/index.cjs
+++ b/servers/telemetry/index.cjs
@@ -3,8 +3,9 @@ const fs = require('fs');
 const path = require('path');
 const analytics = require('./analytics.cjs');
 const { logError, parseJson } = require('../utils.cjs');
+const { telemetry: defaultPort } = require('../ports.cjs');
 
-const port = process.env.PORT || 8090;
+const port = process.env.PORT || defaultPort;
 const logDir = path.join(__dirname, 'logs');
 fs.mkdirSync(logDir, { recursive: true });
 const logFile = path.join(logDir, 'events.log');

--- a/test-menu.ps1
+++ b/test-menu.ps1
@@ -34,7 +34,14 @@ if (-not $Port) {
             Write-Warning "Failed to load engine config from $ConfigFile: $_"
         }
     }
-    if (-not $Port) { $Port = if ($Engine -eq 'godot') { 8002 } else { 8001 } }
+    if (-not $Port) {
+        $portsPath = Join-Path $PSScriptRoot 'servers/ports.cjs'
+        if ($Engine -eq 'godot') {
+            $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.godot);" $portsPath)
+        } else {
+            $Port = [int](node -e "const p=require(process.argv[1]);console.log(p.unity);" $portsPath)
+        }
+    }
 }
 
 if (-not (Test-ValidPort -Port $Port)) {

--- a/tests/aidirector.test.cjs
+++ b/tests/aidirector.test.cjs
@@ -26,7 +26,8 @@ function request(port, options = {}) {
 }
 
 (async () => {
-  const port = 8101;
+  const ports = require('../servers/ports.cjs');
+  const port = ports.aidirector || 8101;
   const server = startServer('servers/aidirector/index.cjs', port);
   try {
     // Wait for server to be ready

--- a/tests/mcp-commands.test.cjs
+++ b/tests/mcp-commands.test.cjs
@@ -1,9 +1,10 @@
 const http = require('http');
 const assert = require('assert');
+const ports = require('../servers/ports.cjs');
 
 function post(body) {
   return new Promise((resolve, reject) => {
-    const req = http.request({ hostname: 'localhost', port: 8001, path: '/mcp', method: 'POST', headers: {'Content-Type':'application/json'} }, res => {
+    const req = http.request({ hostname: 'localhost', port: ports.unity, path: '/mcp', method: 'POST', headers: {'Content-Type':'application/json'} }, res => {
       res.resume();
       res.on('end', resolve);
     });
@@ -20,7 +21,7 @@ function post(body) {
     req.on('data', c => body += c);
     req.on('end', () => { received.push(JSON.parse(body)); res.end('ok'); });
   });
-  await new Promise(r => server.listen(8001, r));
+  await new Promise(r => server.listen(ports.unity, r));
   try {
     await post({ method: 'execute_menu_item', params: { menuPath: 'Test/Path' }, id: '1' });
     await post({ method: 'notify_message', params: { message: 'hi', logType: 'Log' }, id: '2' });

--- a/tests/test-servers.ps1
+++ b/tests/test-servers.ps1
@@ -1,10 +1,13 @@
 param(
-    [int]$GitPort = 8080,
-    [int]$PostgresPort = 8003
+    [int]$GitPort,
+    [int]$PostgresPort
 )
 
 $scriptDir = $PSScriptRoot
 $root = Split-Path -Parent $scriptDir
+$portsPath = Join-Path $root 'servers/ports.cjs'
+if (-not $GitPort) { $GitPort = [int](node -e "const p=require(process.argv[1]);console.log(p.git);" $portsPath) }
+if (-not $PostgresPort) { $PostgresPort = [int](node -e "const p=require(process.argv[1]);console.log(p.postgres);" $portsPath) }
 
 $gitScript = Join-Path $root 'servers/git/index.js'
 $pgScript  = Join-Path $root 'servers/postgres/index.js'


### PR DESCRIPTION
## Summary
- add `servers/ports.cjs` to load ports from `engine-config.json`
- update Node servers to import default ports from this module
- refactor PowerShell helpers to retrieve default ports via Node
- update tests to use the new configuration module

## Testing
- `npx eslint servers tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688784b1016483269ef072c5fe52aae7