### PR TITLE
Add telemetry metrics for event rate

### DIFF
--- a/Documentation/Technical/Telemetry_Reports.md
+++ b/Documentation/Technical/Telemetry_Reports.md
@@ -7,6 +7,8 @@ module aggregates these events to provide high level metrics useful for debuggin
 - **totalEvents** – number of events processed.
 - **eventCounts** – count of each event type.
 - **latestGeneration** – highest `generation` value seen in `generation_advanced` events.
+- **averageEventsPerMinute** – events processed divided by minutes since the first event.
+- **mostRecentEventType** – `type` of the last processed event.
 
 Developers can parse a log file directly:
 

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -3,7 +3,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
-const { logError } = require('../utils.cjs');
+const { logError, parseJson } = require('../utils.cjs');
 const { ksa: defaultPort } = require('../ports.cjs');
 
 

--- a/servers/telemetry/analytics.cjs
+++ b/servers/telemetry/analytics.cjs
@@ -4,22 +4,36 @@ const metrics = {
   totalEvents: 0,
   eventCounts: {},
   latestGeneration: null,
+  averageEventsPerMinute: 0,
+  mostRecentEventType: null,
+  startTime: null,
+  lastEventTime: null,
 };
 
 function resetMetrics() {
   metrics.totalEvents = 0;
   metrics.eventCounts = {};
   metrics.latestGeneration = null;
+  metrics.averageEventsPerMinute = 0;
+  metrics.mostRecentEventType = null;
+  metrics.startTime = null;
+  metrics.lastEventTime = null;
 }
 
 function updateMetrics(event) {
   if (!event || typeof event !== 'object') return;
   if (typeof event.type !== 'string') return;
+  const now = event.timestamp ? new Date(event.timestamp).getTime() : Date.now();
+  if (!metrics.startTime) metrics.startTime = now;
+  metrics.lastEventTime = now;
   metrics.totalEvents += 1;
   metrics.eventCounts[event.type] = (metrics.eventCounts[event.type] || 0) + 1;
+  metrics.mostRecentEventType = event.type;
   if (event.type === 'generation_advanced' && typeof event.generation === 'number') {
     metrics.latestGeneration = event.generation;
   }
+  const durationMinutes = (metrics.lastEventTime - metrics.startTime) / 60000;
+  metrics.averageEventsPerMinute = durationMinutes > 0 ? metrics.totalEvents / durationMinutes : metrics.totalEvents;
 }
 
 function computeMetrics(event) {
@@ -28,22 +42,29 @@ function computeMetrics(event) {
 
 function parseLogFile(filePath) {
   resetMetrics();
-  if (!fs.existsSync(filePath)) return metrics;
-  const contents = fs.readFileSync(filePath, 'utf8');
-  const lines = contents.split(/\r?\n/).filter(Boolean);
-  for (const line of lines) {
-    try {
-      const evt = JSON.parse(line);
-      updateMetrics(evt);
-    } catch {
-      // ignore invalid json
+  if (fs.existsSync(filePath)) {
+    const contents = fs.readFileSync(filePath, 'utf8');
+    const lines = contents.split(/\r?\n/).filter(Boolean);
+    for (const line of lines) {
+      try {
+        const evt = JSON.parse(line);
+        updateMetrics(evt);
+      } catch {
+        // ignore invalid json
+      }
     }
   }
-  return metrics;
+  return getMetrics();
 }
 
 function getMetrics() {
-  return metrics;
+  return {
+    totalEvents: metrics.totalEvents,
+    eventCounts: metrics.eventCounts,
+    latestGeneration: metrics.latestGeneration,
+    averageEventsPerMinute: metrics.averageEventsPerMinute,
+    mostRecentEventType: metrics.mostRecentEventType,
+  };
 }
 
 module.exports = {

--- a/tests/analytics.test.cjs
+++ b/tests/analytics.test.cjs
@@ -25,13 +25,18 @@ if (fs.existsSync(emptyLogPath)) fs.unlinkSync(emptyLogPath);
     assert.strictEqual(metrics.eventCounts.test, 1);
     assert.strictEqual(metrics.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics.latestGeneration, 3);
+    assert.strictEqual(metrics.mostRecentEventType, 'generation_advanced');
+    assert.strictEqual(typeof metrics.averageEventsPerMinute, 'number');
+    assert.ok(metrics.averageEventsPerMinute > 0);
 
     const metricsAgain = analytics.parseLogFile(logPath);
     assert.deepStrictEqual(metricsAgain, metrics);
 
     analytics.resetMetrics();
     analytics.computeMetrics({ type: 'generation_advanced', generation: 5 });
-    assert.strictEqual(analytics.getMetrics().latestGeneration, 5);
+    const liveMetrics = analytics.getMetrics();
+    assert.strictEqual(liveMetrics.latestGeneration, 5);
+    assert.strictEqual(liveMetrics.mostRecentEventType, 'generation_advanced');
 
     // Parse an empty log file and ensure metrics stay zero
     await fs.promises.writeFile(emptyLogPath, '');
@@ -39,6 +44,8 @@ if (fs.existsSync(emptyLogPath)) fs.unlinkSync(emptyLogPath);
     assert.strictEqual(emptyMetrics.totalEvents, 0);
     assert.deepStrictEqual(emptyMetrics.eventCounts, {});
     assert.strictEqual(emptyMetrics.latestGeneration, null);
+    assert.strictEqual(emptyMetrics.averageEventsPerMinute, 0);
+    assert.strictEqual(emptyMetrics.mostRecentEventType, null);
     // parseLogFile resets internal metrics so getMetrics should match
     assert.deepStrictEqual(analytics.getMetrics(), emptyMetrics);
 

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -156,15 +156,26 @@ function post(port, pathName, data) {
     assert.strictEqual(metrics.eventCounts.test, 1);
     assert.strictEqual(metrics.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics.latestGeneration, 1);
+    assert.strictEqual(metrics.mostRecentEventType, 'generation_advanced');
+    assert.strictEqual(typeof metrics.averageEventsPerMinute, 'number');
+    assert.ok(metrics.averageEventsPerMinute > 0);
 
     const metrics2 = analytics.parseLogFile(logPath);
     assert.strictEqual(metrics2.totalEvents, 2);
     assert.strictEqual(metrics2.eventCounts.test, 1);
     assert.strictEqual(metrics2.eventCounts.generation_advanced, 1);
     assert.strictEqual(metrics2.latestGeneration, 1);
+    assert.strictEqual(metrics2.mostRecentEventType, 'generation_advanced');
+    assert.strictEqual(typeof metrics2.averageEventsPerMinute, 'number');
+    assert.ok(metrics2.averageEventsPerMinute > 0);
 
-    const metricsResult = await request(corePort, '/telemetry/metrics');
-    assert.deepStrictEqual(JSON.parse(metricsResult), metrics2);
+    const metricsResult = JSON.parse(await request(corePort, '/telemetry/metrics'));
+    assert.strictEqual(metricsResult.totalEvents, metrics2.totalEvents);
+    assert.deepStrictEqual(metricsResult.eventCounts, metrics2.eventCounts);
+    assert.strictEqual(metricsResult.latestGeneration, metrics2.latestGeneration);
+    assert.strictEqual(metricsResult.mostRecentEventType, metrics2.mostRecentEventType);
+    assert.strictEqual(typeof metricsResult.averageEventsPerMinute, 'number');
+    assert.ok(metricsResult.averageEventsPerMinute > 0);
     console.log('Tests passed');
     core.kill();
     ksa.kill();


### PR DESCRIPTION
## Summary
- include `parseJson` import for the KSA server
- store metric timestamps internally and return a sanitized view
- extend server metrics test for new analytics data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68878989f6b88326ba2e36770e95507f