### PR TITLE
Add verification for MCP server scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test:godot": "if command -v dotnet >/dev/null 2>&1 && [ -x ./godot/godot ]; then dotnet build Godot.Tests/Godot.Tests.csproj && ./godot/godot --headless --path Godot.Tests --run-tests --quit-on-finish; else echo 'dotnet or godot not found, skipping Godot tests'; fi",
-    "test": "node tests/utils.test.cjs && node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && node tests/godot-server.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
+    "test": "node tests/utils.test.cjs && node tests/server.test.cjs && node tests/aidirector.test.cjs && node tests/analytics.test.cjs && node tests/ksa-adapter.test.cjs && node tests/mcp-commands.test.cjs && node tests/godot-server.test.cjs && node tests/helpers/run-all-mcp-servers.test.cjs && if command -v unity-editor >/dev/null 2>&1; then unity-editor -batchmode -nographics -runTests -projectPath \"TBD SpaceGame/TBD SpaceGame\" -testResults UnityTestResults.xml; else echo 'unity-editor not found, skipping Unity tests'; fi && npm run test:godot",
     "lint": "eslint servers tests",
     "start:core-mcp": "node servers/core-mcp/index.cjs"
   },

--- a/servers/ksa/index.cjs
+++ b/servers/ksa/index.cjs
@@ -3,7 +3,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
-const { logError } = require('../utils.cjs');
+const { logError, parseJson } = require('../utils.cjs');
 const { ksa: defaultPort } = require('../ports.cjs');
 
 

--- a/tests/helpers/run-all-mcp-servers.test.cjs
+++ b/tests/helpers/run-all-mcp-servers.test.cjs
@@ -1,0 +1,86 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const getFreePort = require('./port.cjs');
+
+function findPowerShell() {
+  if (!spawnSync('pwsh', ['-Command', '$PSVersionTable.PSVersion']).error) {
+    return 'pwsh';
+  }
+  if (!spawnSync('powershell', ['-Command', '$PSVersionTable.PSVersion']).error) {
+    return 'powershell';
+  }
+  return null;
+}
+
+(async () => {
+  const shell = findPowerShell();
+  if (!shell) {
+    console.log('PowerShell not found, skipping run-all-mcp-servers test');
+    process.exit(0);
+  }
+
+  const names = ['unity', 'git', 'postgres', 'telemetry', 'mcpproxy', 'ksa'];
+  const ports = {};
+  for (const name of names) {
+    ports[name] = await getFreePort();
+  }
+  const config = {};
+  for (const [name, port] of Object.entries(ports)) {
+    config[name] = { port };
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, 'mcp-'));
+  const configPath = path.join(tmpDir, 'engine-config.json');
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+  const root = path.join(__dirname, '..', '..');
+  const runScript = path.join(root, 'run-all-mcp-servers.ps1');
+  const stopScript = path.join(root, 'stop-all-mcp-servers.ps1');
+  const pidDir = path.join(root, 'tmp', 'pids');
+
+  if (fs.existsSync(pidDir)) {
+    fs.rmSync(pidDir, { recursive: true, force: true });
+  }
+
+  const runResult = spawnSync(shell, ['-File', runScript, '-ConfigFile', configPath], {
+    stdio: 'inherit'
+  });
+  assert.strictEqual(runResult.status, 0, 'Failed to start MCP servers');
+
+  await new Promise(r => setTimeout(r, 1000));
+
+  const pidFiles = ['unity.pid', 'git.pid', 'postgres.pid', 'telemetry.pid', 'proxy.pid', 'ksa.pid'];
+  const pids = [];
+  for (const file of pidFiles) {
+    const full = path.join(pidDir, file);
+    assert.ok(fs.existsSync(full), `${file} not created`);
+    const pid = parseInt(fs.readFileSync(full, 'utf8'), 10);
+    assert.ok(pid > 0, `Invalid pid in ${file}`);
+    pids.push(pid);
+  }
+
+  const stopResult = spawnSync(shell, ['-File', stopScript, '-PidDirectory', pidDir], {
+    stdio: 'inherit'
+  });
+  assert.strictEqual(stopResult.status, 0, 'Failed to stop MCP servers');
+
+  for (const file of pidFiles) {
+    assert.ok(!fs.existsSync(path.join(pidDir, file)), `${file} still exists`);
+  }
+
+  for (const pid of pids) {
+    let running = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      running = false;
+    }
+    assert.strictEqual(running, false, `Process ${pid} still running`);
+  }
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+
+  console.log('run-all-mcp-servers test passed');
+})();


### PR DESCRIPTION
## Summary
- ensure MCP server helper test checks PowerShell script exits successfully
- keep test inclusion in package.json

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68878988ee88832696022dbbcb2c0807