### PR TITLE
Add USD export scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Export glTF assets from Unity or Blender:
 ./export-assets.ps1
 ```
 For Unix systems use `./export-assets.sh` instead.
+
+Export USD assets for O3DE:
+```powershell
+./export-to-usd.ps1
+```
+For Unix systems use `./export-to-usd.sh`.

--- a/export-to-usd.ps1
+++ b/export-to-usd.ps1
@@ -1,0 +1,22 @@
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$srcDir = Join-Path $repoRoot 'Assets_glTF'
+$destDir = Join-Path $repoRoot 'Assets_USD'
+New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+
+$usdFromGltf = Get-Command usd_from_gltf -ErrorAction SilentlyContinue
+if (-not $usdFromGltf) {
+    Write-Warning 'usd_from_gltf not found. Install USD tools.'
+    exit 1
+}
+$usdzip = Get-Command usdzip -ErrorAction SilentlyContinue
+
+Get-ChildItem $srcDir -Include *.gltf,*.glb -Recurse | ForEach-Object {
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($_.FullName)
+    $usdPath = Join-Path $destDir ("$base.usda")
+    & $usdFromGltf.Source $_.FullName $usdPath
+    if ($usdzip) {
+        & $usdzip.Source $usdPath (Join-Path $destDir ("$base.usdz")) -f
+    }
+    Write-Host "Converted $($_.Name) -> $usdPath"
+}
+Write-Host "USD files exported to $destDir"

--- a/export-to-usd.sh
+++ b/export-to-usd.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+repo_root="$(cd "$(dirname "$0")" && pwd)"
+src_dir="$repo_root/Assets_glTF"
+dest_dir="$repo_root/Assets_USD"
+mkdir -p "$dest_dir"
+
+if ! command -v usd_from_gltf >/dev/null 2>&1; then
+    echo "usd_from_gltf not found. Install USD tools." >&2
+    exit 1
+fi
+
+shopt -s nullglob
+for file in "$src_dir"/*.gltf "$src_dir"/*.glb; do
+    base="$(basename "${file%.*}")"
+    usd_file="$dest_dir/$base.usda"
+    usd_from_gltf "$file" "$usd_file"
+    if command -v usdzip >/dev/null 2>&1; then
+        usdzip "$usd_file" "$dest_dir/$base.usdz" -f
+    fi
+    echo "Converted $file -> $usd_file"
+done
+shopt -u nullglob
+
+echo "USD files exported to $dest_dir"


### PR DESCRIPTION
## Summary
- add `export-to-usd.ps1` and `export-to-usd.sh` for converting glTF to USD
- document USD export workflow for O3DE in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887910a7e008326b20d6f194f1c16ac