### PR TITLE
Add WebSocket integration test

### DIFF
--- a/Godot.Tests/Godot.Tests.csproj
+++ b/Godot.Tests/Godot.Tests.csproj
@@ -11,20 +11,22 @@
   <ItemGroup>
     <PackageReference Include="Chickensoft.GoDotTest" Version="1.7.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
+    <ProjectReference Include="../servers/godot/GodotServer.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../csharp/GodotStubs/HttpRequestExtensions.cs" />
     <Compile Include="../src/OrbitalMechanics/OrbitPlanner.cs" />
+    <Compile Include="../src/OrbitalMechanics/OrbitFollower.cs" />
     <Compile Include="test/stubs/CelestialBody.cs" />
     <Compile Include="../src/OrbitalMechanics/OrbitData.cs" />
     <Compile Include="../src/OrbitalMechanics/Vector3d.cs" />
     <Compile Include="../src/SimpleKeplerOrbits/*.cs" />
     <Compile Include="../src/ShipCustomization/ShipCustomizationManager.cs" />
+    <Compile Include="../src/ShipCustomization/SpaceshipMovement.cs" />
     <Compile Include="../src/ShipCustomization/ShipUpgradeMenuHelper.cs" />
     <Compile Include="../src/GameState/GameState.cs" />
     <Compile Include="../Godot/Scripts/*.cs" />
     <Compile Include="test/Tests.cs" />
-    <Compile Include="test/src/ShipUpgradeMenuHelperTests.cs" />
     <Compile Include="test/src/*.cs" />
   </ItemGroup>
 </Project>

--- a/Godot.Tests/test/src/GodotServerIntegrationTests.cs
+++ b/Godot.Tests/test/src/GodotServerIntegrationTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Godot;
+using Chickensoft.GoDotTest;
+using Shouldly;
+
+public class GodotServerIntegrationTests : TestClass {
+    public GodotServerIntegrationTests(Node scene) : base(scene) { }
+
+    [Test]
+    public async Task ExecuteMenuItemAndShutdown() {
+        int port = GetFreePort();
+        using var server = new SimpleWebSocketServer(port);
+        server.Start();
+
+        var client = new McpClient { Endpoint = $"ws://localhost:{port}/" };
+        TestScene.AddChild(client);
+        var resp = await client.SendWebSocketCommand("open");
+
+        resp.GetProperty("result").GetProperty("executed").GetString().ShouldBe("open");
+
+        server.Stop();
+
+        await Should.ThrowAsync<WebSocketException>(async () => {
+            using var ws = new ClientWebSocket();
+            await ws.ConnectAsync(new Uri($"ws://localhost:{port}/"), CancellationToken.None);
+        });
+    }
+
+    private static int GetFreePort() {
+        var l = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        int p = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return p;
+    }
+}

--- a/Godot.Tests/test/src/McpClientLogHelper.cs
+++ b/Godot.Tests/test/src/McpClientLogHelper.cs
@@ -1,4 +1,5 @@
 public partial class McpClient {
     public string? LastLoggedError { get; private set; }
+    partial void LogError(string message);
     partial void LogErrorExtra(string message) => LastLoggedError = message;
 }

--- a/Godot.Tests/test/src/McpWebSocketClient.cs
+++ b/Godot.Tests/test/src/McpWebSocketClient.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+public partial class McpClient {
+    public async Task<JsonElement> SendWebSocketCommand(string item) {
+        var uri = new Uri(Endpoint);
+        if (!uri.Scheme.StartsWith("ws"))
+            uri = new Uri($"ws://{uri.Host}:{uri.Port}/");
+        using var ws = new ClientWebSocket();
+        await ws.ConnectAsync(uri, CancellationToken.None);
+        var id = Guid.NewGuid().ToString();
+        var payload = JsonSerializer.Serialize(new {
+            type = "execute_menu_item",
+            id,
+            parameters = new { item }
+        });
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+        var buffer = new byte[1024];
+        var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+        var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+}

--- a/Godot/Scripts/McpClient.cs
+++ b/Godot/Scripts/McpClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using SystemHttpClient = System.Net.Http.HttpClient;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -39,7 +40,7 @@ public partial class McpClient : Control
         var json = JsonSerializer.Serialize(payload);
         var req = new HttpRequest();
         AddChild(req);
-        var err = req.Request(Endpoint, new string[] { "Content-Type: application/json" }, HttpClient.Method.Post, json);
+        var err = req.Request(Endpoint, new string[] { "Content-Type: application/json" }, Godot.HttpClient.Method.Post, json);
         if (err != Error.Ok)
         {
             GD.PrintErr($"Request failed: {err}");
@@ -73,7 +74,7 @@ public partial class McpClient : Control
     {
         try
         {
-            using var client = new HttpClient();
+            using var client = new SystemHttpClient();
             var json = JsonSerializer.Serialize(new { type = "godot_error", message });
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             await client.PostAsync("http://localhost:8090/event", content);

--- a/src/OrbitalMechanics/OrbitFollower.cs
+++ b/src/OrbitalMechanics/OrbitFollower.cs
@@ -6,7 +6,7 @@ namespace OrbitalMechanics
     /// Follows a predefined orbit using data from OrbitData.
     /// </summary>
 
-    public class OrbitFollower : Node3D
+    public partial class OrbitFollower : Node3D
     {
         private OrbitData _orbit;
 


### PR DESCRIPTION
## Summary
- add project reference to Godot server
- include OrbitFollower and SpaceshipMovement files
- extend McpClient with WebSocket helper for tests
- add integration test spinning up the server
- make OrbitFollower partial
- qualify HttpClient usages

## Testing
- `npm run lint`
- `npm test` *(Godot tests skipped because the engine binary is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688794cdd29c83269ba364c8c6d3797d